### PR TITLE
Feat: Session/cookie support for authenticated scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Scrape a URL and return its content as markdown, text, HTML, or JSON. Automatica
 | `wait_for` | string | &mdash; | CSS selector to wait for before extraction |
 | `timeout` | number | `90` | Timeout in seconds (1-300) |
 | `include_raw_html` | boolean | `false` | Include raw HTML alongside formatted content |
+| `session_id` | string (UUID) | &mdash; | Stored session ID for authenticated scraping |
+| `cookies` | `Record<string, string>` | &mdash; | Inline cookies for one-off authenticated requests |
 
 ### `alterlab_extract` &mdash; Extract Structured Data
 
@@ -230,6 +232,80 @@ Check your account balance, total deposited, and total spent. No parameters need
 ```
 "Check my AlterLab balance"
 ```
+
+### `alterlab_list_sessions` &mdash; List Stored Sessions
+
+List all stored sessions for authenticated scraping. Sessions contain cookies for specific domains, allowing you to scrape content behind login walls.
+
+```
+"List my stored sessions"
+```
+
+### `alterlab_create_session` &mdash; Create a Session
+
+Create a new stored session with cookies from a logged-in browser. The session is stored securely and can be reused across multiple scrape requests.
+
+```
+"Create an Amazon session with these cookies: session-id=abc123, session-token=xyz789"
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | required | Human-readable name (e.g., "My Amazon Account") |
+| `domain` | string | required | Domain (e.g., "amazon.com") |
+| `cookies` | `Record<string, string>` | required | Cookie key-value pairs |
+| `user_agent` | string | &mdash; | Browser User-Agent to use with this session |
+
+### `alterlab_validate_session` &mdash; Validate a Session
+
+Check whether a stored session is still active and its cookies are valid.
+
+```
+"Is my Amazon session still valid?"
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `session_id` | string (UUID) | required | Session ID to validate |
+
+### `alterlab_delete_session` &mdash; Delete a Session
+
+Permanently delete a stored session and its cookies.
+
+```
+"Delete session abc-123-def"
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `session_id` | string (UUID) | required | Session ID to delete |
+
+---
+
+## Authenticated Scraping
+
+AlterLab MCP supports scraping pages that require authentication. This enables AI agents to access user-specific content like order histories, account dashboards, and member-only pricing.
+
+### How It Works
+
+1. **Create a session** with cookies from a logged-in browser using `alterlab_create_session`
+2. **Scrape authenticated pages** by passing the `session_id` to `alterlab_scrape`
+3. **Manage sessions** with list, validate, and delete tools
+
+### Example: Check Amazon Prime Pricing
+
+```
+User: "What's my Prime member price for this product?"
+
+Claude: [calls alterlab_list_sessions → finds Amazon session]
+Claude: [calls alterlab_scrape with session_id for authenticated pricing]
+Claude: "The Prime member price is $24.99 (public price: $34.99)"
+```
+
+### Inline Cookies vs Stored Sessions
+
+- **Stored sessions** (`session_id`): Best for repeated access to the same domain. Create once, reuse across requests.
+- **Inline cookies** (`cookies`): Best for one-off authenticated requests where you don't need to save the session.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "alterlab-mcp-server",
-  "version": "1.0.0",
-  "description": "MCP server for AlterLab web scraping API — scrape, extract, screenshot any webpage",
+  "version": "1.1.0",
+  "description": "MCP server for AlterLab web scraping API — scrape, extract, screenshot, and authenticated scraping",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,13 +3,18 @@ import { type ApiError } from "./errors.js";
 import {
   type BalanceResponse,
   type CostEstimate,
+  type Session,
+  type SessionCreateRequest,
+  type SessionCreateResponse,
+  type SessionListResponse,
+  type SessionValidateResponse,
   type UnifiedScrapeRequest,
   type UnifiedScrapeResponse,
 } from "./types.js";
 
 // Read version from package.json at build time is complex with ESM,
 // so we hardcode it and keep in sync with package.json.
-const VERSION = "1.0.0";
+const VERSION = "1.1.0";
 const MAX_RETRIES = 2;
 
 export class AlterLabClient {
@@ -95,6 +100,34 @@ export class AlterLabClient {
 
   async getBalance(): Promise<BalanceResponse> {
     return this.request<BalanceResponse>("GET", "/api/v1/billing/balance");
+  }
+
+  async listSessions(): Promise<SessionListResponse> {
+    return this.request<SessionListResponse>("GET", "/api/v1/sessions/");
+  }
+
+  async createSession(
+    params: SessionCreateRequest
+  ): Promise<SessionCreateResponse> {
+    return this.request<SessionCreateResponse>(
+      "POST",
+      "/api/v1/sessions/",
+      params
+    );
+  }
+
+  async validateSession(sessionId: string): Promise<SessionValidateResponse> {
+    return this.request<SessionValidateResponse>(
+      "POST",
+      `/api/v1/sessions/${sessionId}/validate`
+    );
+  }
+
+  async deleteSession(sessionId: string): Promise<{ deleted: boolean }> {
+    return this.request<{ deleted: boolean }>(
+      "DELETE",
+      `/api/v1/sessions/${sessionId}`
+    );
   }
 
   async fetchScreenshotAsBase64(screenshotUrl: string): Promise<string> {

--- a/src/format.ts
+++ b/src/format.ts
@@ -3,6 +3,9 @@ import {
   TIER_PRICES,
   type BalanceResponse,
   type CostEstimate,
+  type SessionCreateResponse,
+  type SessionListResponse,
+  type SessionValidateResponse,
   type UnifiedScrapeResponse,
 } from "./types.js";
 
@@ -142,4 +145,92 @@ export function formatBalanceResponse(balance: BalanceResponse): string {
     `- Total spent: $${spent}\n\n` +
     `Add funds: https://alterlab.io/dashboard/billing`
   );
+}
+
+/**
+ * Format a session list response as readable text.
+ */
+export function formatSessionListResponse(
+  response: SessionListResponse
+): string {
+  if (response.sessions.length === 0) {
+    return (
+      "**No sessions found.**\n\n" +
+      "Create a session with `alterlab_create_session` to enable authenticated scraping.\n" +
+      "You'll need cookies from a logged-in browser session for the target domain."
+    );
+  }
+
+  const parts: string[] = [
+    `**Stored Sessions** (${response.total} total)\n`,
+  ];
+
+  for (const session of response.sessions) {
+    const status =
+      session.status === "active"
+        ? "Active"
+        : session.status === "expired"
+          ? "Expired"
+          : "Invalid";
+    const lastUsed = session.last_used_at
+      ? `Last used: ${session.last_used_at}`
+      : "Never used";
+
+    parts.push(
+      `- **${session.name}** (\`${session.id}\`)\n` +
+        `  Domain: ${session.domain} | Status: ${status} | ` +
+        `Cookies: ${session.cookie_count} | ${lastUsed}`
+    );
+  }
+
+  parts.push(
+    "\nUse a session_id with `alterlab_scrape` to scrape authenticated pages."
+  );
+
+  return parts.join("\n");
+}
+
+/**
+ * Format a session create response.
+ */
+export function formatSessionCreateResponse(
+  response: SessionCreateResponse
+): string {
+  return (
+    `**Session Created**\n\n` +
+    `- Name: **${response.name}**\n` +
+    `- ID: \`${response.id}\`\n` +
+    `- Domain: ${response.domain}\n` +
+    `- Status: ${response.status}\n\n` +
+    `Use this session_id with \`alterlab_scrape\` to scrape authenticated pages on ${response.domain}.`
+  );
+}
+
+/**
+ * Format a session validation response.
+ */
+export function formatSessionValidateResponse(
+  response: SessionValidateResponse
+): string {
+  const statusIcon = response.valid ? "Valid" : "Invalid";
+  const parts = [
+    `**Session Validation: ${statusIcon}**\n`,
+    `- Name: **${response.name}**`,
+    `- ID: \`${response.id}\``,
+    `- Domain: ${response.domain}`,
+    `- Status: ${response.status}`,
+  ];
+
+  if (response.reason) {
+    parts.push(`- Reason: ${response.reason}`);
+  }
+
+  if (!response.valid) {
+    parts.push(
+      "\nThis session can no longer be used for authenticated scraping. " +
+        "Create a new session with fresh cookies using `alterlab_create_session`."
+    );
+  }
+
+  return parts.join("\n");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,13 +13,27 @@ import {
 } from "./tools/screenshot.js";
 import { estimateSchema, estimateDescription, handleEstimate } from "./tools/estimate.js";
 import { balanceSchema, balanceDescription, handleBalance } from "./tools/balance.js";
+import {
+  listSessionsSchema,
+  listSessionsDescription,
+  handleListSessions,
+  createSessionSchema,
+  createSessionDescription,
+  handleCreateSession,
+  validateSessionSchema,
+  validateSessionDescription,
+  handleValidateSession,
+  deleteSessionSchema,
+  deleteSessionDescription,
+  handleDeleteSession,
+} from "./tools/sessions.js";
 
 function createServer(config: Config): McpServer {
   const client = new AlterLabClient(config);
 
   const server = new McpServer({
     name: "alterlab",
-    version: "1.0.0",
+    version: "1.1.0",
   });
 
   // Register tools
@@ -44,6 +58,35 @@ function createServer(config: Config): McpServer {
 
   server.tool("alterlab_check_balance", balanceDescription, balanceSchema.shape, () =>
     handleBalance(client)
+  );
+
+  // Session management tools
+  server.tool(
+    "alterlab_list_sessions",
+    listSessionsDescription,
+    listSessionsSchema.shape,
+    () => handleListSessions(client)
+  );
+
+  server.tool(
+    "alterlab_create_session",
+    createSessionDescription,
+    createSessionSchema.shape,
+    (params) => handleCreateSession(client, params as any)
+  );
+
+  server.tool(
+    "alterlab_validate_session",
+    validateSessionDescription,
+    validateSessionSchema.shape,
+    (params) => handleValidateSession(client, params as any)
+  );
+
+  server.tool(
+    "alterlab_delete_session",
+    deleteSessionDescription,
+    deleteSessionSchema.shape,
+    (params) => handleDeleteSession(client, params as any)
   );
 
   return server;

--- a/src/tools/scrape.ts
+++ b/src/tools/scrape.ts
@@ -40,6 +40,23 @@ export const scrapeSchema = z.object({
     .boolean()
     .default(false)
     .describe("Include raw HTML in the response alongside formatted content"),
+  session_id: z
+    .string()
+    .uuid()
+    .optional()
+    .describe(
+      "UUID of a stored session for authenticated scraping. " +
+      "Use alterlab_list_sessions to find available sessions. " +
+      "The session's cookies will be injected into the request."
+    ),
+  cookies: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe(
+      "Inline cookies as key-value pairs for authenticated scraping " +
+      "(e.g., {\"session_token\": \"abc123\"}). " +
+      "Use this for one-off requests; use session_id for reusable sessions."
+    ),
 });
 
 export const scrapeDescription =
@@ -47,7 +64,8 @@ export const scrapeDescription =
   "Automatically handles anti-bot protection with tier escalation. " +
   "Returns markdown by default — optimized for LLM context. " +
   "Use render_js=true for JavaScript-heavy sites (React, Angular, SPAs). " +
-  "Use use_proxy=true for geo-restricted or heavily protected sites.";
+  "Use use_proxy=true for geo-restricted or heavily protected sites. " +
+  "Supports authenticated scraping via session_id (stored session) or inline cookies.";
 
 export async function handleScrape(
   client: AlterLabClient,
@@ -62,6 +80,8 @@ export async function handleScrape(
       timeout: params.timeout,
       include_raw_html: params.include_raw_html,
       wait_for: params.wait_for,
+      session_id: params.session_id,
+      cookies: params.cookies,
       advanced: {
         render_js: params.render_js,
         use_proxy: params.use_proxy,

--- a/src/tools/sessions.ts
+++ b/src/tools/sessions.ts
@@ -1,0 +1,172 @@
+import { z } from "zod";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { AlterLabClient } from "../client.js";
+import { type ApiError, formatErrorResult } from "../errors.js";
+import { formatSessionListResponse, formatSessionCreateResponse, formatSessionValidateResponse } from "../format.js";
+
+// ============================================================================
+// List Sessions
+// ============================================================================
+
+export const listSessionsSchema = z.object({});
+
+export const listSessionsDescription =
+  "List all stored sessions for authenticated scraping. " +
+  "Sessions contain cookies for specific domains, allowing you to scrape " +
+  "content that requires login (e.g., Amazon order history, LinkedIn profiles). " +
+  "Use the returned session_id with alterlab_scrape to scrape authenticated pages.";
+
+export async function handleListSessions(
+  client: AlterLabClient
+): Promise<CallToolResult> {
+  try {
+    const response = await client.listSessions();
+    return {
+      content: [{ type: "text", text: formatSessionListResponse(response) }],
+    };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error);
+    }
+    return formatErrorResult(error as Error);
+  }
+}
+
+// ============================================================================
+// Create Session
+// ============================================================================
+
+export const createSessionSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(100)
+    .describe("Human-readable name for this session (e.g., 'My Amazon Account')"),
+  domain: z
+    .string()
+    .min(1)
+    .describe("Domain this session is for (e.g., 'amazon.com')"),
+  cookies: z
+    .record(z.string(), z.string())
+    .describe(
+      "Cookie key-value pairs for authentication " +
+      "(e.g., {\"session-id\": \"abc123\", \"session-token\": \"xyz789\"})"
+    ),
+  user_agent: z
+    .string()
+    .optional()
+    .describe("Browser User-Agent string to use with this session"),
+});
+
+export const createSessionDescription =
+  "Create a new stored session for authenticated scraping. " +
+  "Provide cookies from a logged-in browser session to enable scraping " +
+  "behind login walls. The session is stored securely and can be reused " +
+  "across multiple scrape requests via session_id.";
+
+export async function handleCreateSession(
+  client: AlterLabClient,
+  params: z.infer<typeof createSessionSchema>
+): Promise<CallToolResult> {
+  try {
+    const response = await client.createSession({
+      name: params.name,
+      domain: params.domain,
+      cookies: params.cookies,
+      user_agent: params.user_agent,
+    });
+    return {
+      content: [{ type: "text", text: formatSessionCreateResponse(response) }],
+    };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error);
+    }
+    return formatErrorResult(error as Error);
+  }
+}
+
+// ============================================================================
+// Validate Session
+// ============================================================================
+
+export const validateSessionSchema = z.object({
+  session_id: z
+    .string()
+    .uuid()
+    .describe("UUID of the session to validate"),
+});
+
+export const validateSessionDescription =
+  "Validate whether a stored session is still active and its cookies are valid. " +
+  "Run this before scraping if you suspect a session may have expired. " +
+  "Returns the session status and a reason if invalid.";
+
+export async function handleValidateSession(
+  client: AlterLabClient,
+  params: z.infer<typeof validateSessionSchema>
+): Promise<CallToolResult> {
+  try {
+    const response = await client.validateSession(params.session_id);
+    return {
+      content: [
+        { type: "text", text: formatSessionValidateResponse(response) },
+      ],
+    };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error);
+    }
+    return formatErrorResult(error as Error);
+  }
+}
+
+// ============================================================================
+// Delete Session
+// ============================================================================
+
+export const deleteSessionSchema = z.object({
+  session_id: z
+    .string()
+    .uuid()
+    .describe("UUID of the session to delete"),
+});
+
+export const deleteSessionDescription =
+  "Delete a stored session. This permanently removes the session and its " +
+  "cookies. Use this when a session is no longer needed or has been compromised.";
+
+export async function handleDeleteSession(
+  client: AlterLabClient,
+  params: z.infer<typeof deleteSessionSchema>
+): Promise<CallToolResult> {
+  try {
+    await client.deleteSession(params.session_id);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Session \`${params.session_id}\` has been deleted.`,
+        },
+      ],
+    };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error);
+    }
+    return formatErrorResult(error as Error);
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function isApiError(error: unknown): error is ApiError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof (error as ApiError).status === "number"
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,53 @@ export interface UnifiedScrapeRequest {
   wait_for?: string;
   screenshot?: boolean;
   wait_until?: string;
+  session_id?: string;
+  cookies?: Record<string, string>;
+}
+
+// ============================================================================
+// Session Types
+// ============================================================================
+
+export interface Session {
+  id: string;
+  name: string;
+  domain: string;
+  status: "active" | "expired" | "invalid";
+  created_at: string;
+  updated_at: string;
+  last_used_at?: string;
+  expires_at?: string;
+  cookie_count: number;
+}
+
+export interface SessionListResponse {
+  sessions: Session[];
+  total: number;
+}
+
+export interface SessionCreateRequest {
+  name: string;
+  domain: string;
+  cookies: Record<string, string>;
+  user_agent?: string;
+}
+
+export interface SessionCreateResponse {
+  id: string;
+  name: string;
+  domain: string;
+  status: "active";
+  created_at: string;
+}
+
+export interface SessionValidateResponse {
+  id: string;
+  name: string;
+  domain: string;
+  status: "active" | "expired" | "invalid";
+  valid: boolean;
+  reason?: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Added `session_id` and `cookies` parameters to `alterlab_scrape` for authenticated scraping
- Added 4 new session management tools: `alterlab_list_sessions`, `alterlab_create_session`, `alterlab_validate_session`, `alterlab_delete_session`
- Updated types, client, and formatting for session API endpoints (`/api/v1/sessions/`)
- Updated README with session tool docs and authenticated scraping guide
- Version bump to 1.1.0

Closes RapierCraft/AlterLab#1825

## Test plan
- [ ] Verify TypeScript builds cleanly (`npm run build`)
- [ ] Test `alterlab_scrape` with `session_id` parameter passes it through to API
- [ ] Test `alterlab_scrape` with `cookies` parameter passes it through to API
- [ ] Test all 4 session management tools against live API
- [ ] Verify Zod validation rejects invalid session_id (non-UUID)