### PR TITLE
Feat: Add missing session tools (get, update, refresh)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -6,7 +6,10 @@ import {
   type Session,
   type SessionCreateRequest,
   type SessionCreateResponse,
+  type SessionDetailResponse,
   type SessionListResponse,
+  type SessionRefreshRequest,
+  type SessionUpdateRequest,
   type SessionValidateResponse,
   type UnifiedScrapeRequest,
   type UnifiedScrapeResponse,
@@ -32,7 +35,7 @@ export class AlterLabClient {
     method: string,
     path: string,
     body?: unknown,
-    retryCount = 0
+    retryCount = 0,
   ): Promise<T> {
     const url = `${this.apiUrl}${path}`;
     const headers: Record<string, string> = {
@@ -78,23 +81,19 @@ export class AlterLabClient {
     return (await response.json()) as T;
   }
 
-  async scrape(
-    params: UnifiedScrapeRequest
-  ): Promise<UnifiedScrapeResponse> {
+  async scrape(params: UnifiedScrapeRequest): Promise<UnifiedScrapeResponse> {
     return this.request<UnifiedScrapeResponse>(
       "POST",
       "/api/v1/scrape",
-      params
+      params,
     );
   }
 
-  async estimate(
-    params: UnifiedScrapeRequest
-  ): Promise<CostEstimate> {
+  async estimate(params: UnifiedScrapeRequest): Promise<CostEstimate> {
     return this.request<CostEstimate>(
       "POST",
       "/api/v1/scrape/estimate",
-      params
+      params,
     );
   }
 
@@ -107,26 +106,55 @@ export class AlterLabClient {
   }
 
   async createSession(
-    params: SessionCreateRequest
+    params: SessionCreateRequest,
   ): Promise<SessionCreateResponse> {
     return this.request<SessionCreateResponse>(
       "POST",
       "/api/v1/sessions/",
-      params
+      params,
     );
   }
 
   async validateSession(sessionId: string): Promise<SessionValidateResponse> {
     return this.request<SessionValidateResponse>(
       "POST",
-      `/api/v1/sessions/${sessionId}/validate`
+      `/api/v1/sessions/${sessionId}/validate`,
+    );
+  }
+
+  async getSession(sessionId: string): Promise<SessionDetailResponse> {
+    return this.request<SessionDetailResponse>(
+      "GET",
+      `/api/v1/sessions/${sessionId}`,
+    );
+  }
+
+  async updateSession(
+    sessionId: string,
+    params: SessionUpdateRequest,
+  ): Promise<SessionDetailResponse> {
+    return this.request<SessionDetailResponse>(
+      "PATCH",
+      `/api/v1/sessions/${sessionId}`,
+      params,
+    );
+  }
+
+  async refreshSession(
+    sessionId: string,
+    params: SessionRefreshRequest,
+  ): Promise<SessionDetailResponse> {
+    return this.request<SessionDetailResponse>(
+      "POST",
+      `/api/v1/sessions/${sessionId}/refresh`,
+      params,
     );
   }
 
   async deleteSession(sessionId: string): Promise<{ deleted: boolean }> {
     return this.request<{ deleted: boolean }>(
       "DELETE",
-      `/api/v1/sessions/${sessionId}`
+      `/api/v1/sessions/${sessionId}`,
     );
   }
 
@@ -145,7 +173,7 @@ export class AlterLabClient {
 
     if (!response.ok) {
       throw new Error(
-        `Failed to fetch screenshot: ${response.status} ${response.statusText}`
+        `Failed to fetch screenshot: ${response.status} ${response.statusText}`,
       );
     }
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -4,6 +4,7 @@ import {
   type BalanceResponse,
   type CostEstimate,
   type SessionCreateResponse,
+  type SessionDetailResponse,
   type SessionListResponse,
   type SessionValidateResponse,
   type UnifiedScrapeResponse,
@@ -37,7 +38,7 @@ export function formatScrapeResponse(response: UnifiedScrapeResponse): string {
           (typeof contentMap.json === "string"
             ? contentMap.json
             : JSON.stringify(contentMap.json, null, 2)) +
-          "\n```"
+          "\n```",
       );
     } else {
       // Unknown structure — dump as JSON
@@ -61,7 +62,7 @@ export function formatScrapeResponse(response: UnifiedScrapeResponse): string {
       `Tier: ${tierName} (${tierPrice}/req) | ` +
       `Cost: ${cost} | ` +
       `Time: ${response.response_time_ms}ms` +
-      (response.cached ? " | Cached" : "")
+      (response.cached ? " | Cached" : ""),
   );
 
   if (response.billing.optimization_suggestion) {
@@ -82,7 +83,10 @@ export function formatExtractResponse(response: UnifiedScrapeResponse): string {
 
   if (response.filtered_content) {
     jsonData = response.filtered_content;
-  } else if (typeof response.content === "object" && response.content !== null) {
+  } else if (
+    typeof response.content === "object" &&
+    response.content !== null
+  ) {
     const contentMap = response.content as Record<string, unknown>;
     jsonData = contentMap.json || contentMap;
   } else {
@@ -95,8 +99,10 @@ export function formatExtractResponse(response: UnifiedScrapeResponse): string {
 
   parts.push(
     "```json\n" +
-      (typeof jsonData === "string" ? jsonData : JSON.stringify(jsonData, null, 2)) +
-      "\n```"
+      (typeof jsonData === "string"
+        ? jsonData
+        : JSON.stringify(jsonData, null, 2)) +
+      "\n```",
   );
 
   // Metadata
@@ -108,7 +114,7 @@ export function formatExtractResponse(response: UnifiedScrapeResponse): string {
       `Source: ${response.url} | ` +
       `Tier: ${tierName} | ` +
       `Method: ${response.extraction_method || "algorithmic"} | ` +
-      `Time: ${response.response_time_ms}ms`
+      `Time: ${response.response_time_ms}ms`,
   );
 
   return parts.join("\n");
@@ -118,7 +124,8 @@ export function formatExtractResponse(response: UnifiedScrapeResponse): string {
  * Format a cost estimate as readable text.
  */
 export function formatEstimateResponse(estimate: CostEstimate): string {
-  const tierName = TIER_NAMES[estimate.estimated_tier] || estimate.estimated_tier;
+  const tierName =
+    TIER_NAMES[estimate.estimated_tier] || estimate.estimated_tier;
   const tierPrice = TIER_PRICES[estimate.estimated_tier] || "unknown";
 
   return (
@@ -151,7 +158,7 @@ export function formatBalanceResponse(balance: BalanceResponse): string {
  * Format a session list response as readable text.
  */
 export function formatSessionListResponse(
-  response: SessionListResponse
+  response: SessionListResponse,
 ): string {
   if (response.sessions.length === 0) {
     return (
@@ -161,9 +168,7 @@ export function formatSessionListResponse(
     );
   }
 
-  const parts: string[] = [
-    `**Stored Sessions** (${response.total} total)\n`,
-  ];
+  const parts: string[] = [`**Stored Sessions** (${response.total} total)\n`];
 
   for (const session of response.sessions) {
     const status =
@@ -179,12 +184,12 @@ export function formatSessionListResponse(
     parts.push(
       `- **${session.name}** (\`${session.id}\`)\n` +
         `  Domain: ${session.domain} | Status: ${status} | ` +
-        `Cookies: ${session.cookie_count} | ${lastUsed}`
+        `Cookies: ${session.cookie_count} | ${lastUsed}`,
     );
   }
 
   parts.push(
-    "\nUse a session_id with `alterlab_scrape` to scrape authenticated pages."
+    "\nUse a session_id with `alterlab_scrape` to scrape authenticated pages.",
   );
 
   return parts.join("\n");
@@ -194,7 +199,7 @@ export function formatSessionListResponse(
  * Format a session create response.
  */
 export function formatSessionCreateResponse(
-  response: SessionCreateResponse
+  response: SessionCreateResponse,
 ): string {
   return (
     `**Session Created**\n\n` +
@@ -210,7 +215,7 @@ export function formatSessionCreateResponse(
  * Format a session validation response.
  */
 export function formatSessionValidateResponse(
-  response: SessionValidateResponse
+  response: SessionValidateResponse,
 ): string {
   const statusIcon = response.valid ? "Valid" : "Invalid";
   const parts = [
@@ -228,9 +233,95 @@ export function formatSessionValidateResponse(
   if (!response.valid) {
     parts.push(
       "\nThis session can no longer be used for authenticated scraping. " +
-        "Create a new session with fresh cookies using `alterlab_create_session`."
+        "Create a new session with fresh cookies using `alterlab_create_session`.",
     );
   }
 
   return parts.join("\n");
+}
+
+/**
+ * Format a session detail response (get session).
+ */
+export function formatSessionDetailResponse(
+  response: SessionDetailResponse,
+): string {
+  const parts = [
+    `**Session: ${response.name}**\n`,
+    `- ID: \`${response.id}\``,
+    `- Domain: ${response.domain}`,
+    `- Status: ${response.status}`,
+    `- Cookies: ${response.cookie_names.length} (${response.cookie_names.join(", ")})`,
+  ];
+
+  if (response.header_names && response.header_names.length > 0) {
+    parts.push(
+      `- Custom headers: ${response.header_names.length} (${response.header_names.join(", ")})`,
+    );
+  }
+
+  if (response.expires_at) {
+    const expiryLabel = response.expiry_status
+      ? ` (${response.expiry_status})`
+      : "";
+    parts.push(`- Expires: ${response.expires_at}${expiryLabel}`);
+  }
+
+  parts.push(
+    `\n**Usage Stats**`,
+    `- Total requests: ${response.total_requests}`,
+    `- Successful: ${response.successful_requests}`,
+    `- Success rate: ${(response.success_rate * 100).toFixed(1)}%`,
+    `- Consecutive failures: ${response.consecutive_failures}`,
+  );
+
+  if (response.last_used_at) {
+    parts.push(`- Last used: ${response.last_used_at}`);
+  }
+  if (response.last_validated_at) {
+    parts.push(`- Last validated: ${response.last_validated_at}`);
+  }
+  if (response.notes) {
+    parts.push(`\n**Notes**: ${response.notes}`);
+  }
+
+  parts.push(`\n- Created: ${response.created_at}`);
+  parts.push(`- Updated: ${response.updated_at}`);
+
+  return parts.join("\n");
+}
+
+/**
+ * Format a session update response.
+ */
+export function formatSessionUpdateResponse(
+  response: SessionDetailResponse,
+): string {
+  return (
+    `**Session Updated**\n\n` +
+    `- Name: **${response.name}**\n` +
+    `- ID: \`${response.id}\`\n` +
+    `- Domain: ${response.domain}\n` +
+    `- Status: ${response.status}\n` +
+    `- Cookies: ${response.cookie_names.length}\n\n` +
+    `Session has been updated successfully.`
+  );
+}
+
+/**
+ * Format a session refresh response.
+ */
+export function formatSessionRefreshResponse(
+  response: SessionDetailResponse,
+): string {
+  return (
+    `**Session Cookies Refreshed**\n\n` +
+    `- Name: **${response.name}**\n` +
+    `- ID: \`${response.id}\`\n` +
+    `- Domain: ${response.domain}\n` +
+    `- Status: ${response.status}\n` +
+    `- Cookies: ${response.cookie_names.length}\n\n` +
+    `Cookies have been rotated and failure counters reset. ` +
+    `The session is ready for authenticated scraping.`
+  );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,15 +4,31 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { AlterLabClient } from "./client.js";
 import { loadConfig, type Config } from "./config.js";
-import { scrapeSchema, scrapeDescription, handleScrape } from "./tools/scrape.js";
-import { extractSchema, extractDescription, handleExtract } from "./tools/extract.js";
+import {
+  scrapeSchema,
+  scrapeDescription,
+  handleScrape,
+} from "./tools/scrape.js";
+import {
+  extractSchema,
+  extractDescription,
+  handleExtract,
+} from "./tools/extract.js";
 import {
   screenshotSchema,
   screenshotDescription,
   handleScreenshot,
 } from "./tools/screenshot.js";
-import { estimateSchema, estimateDescription, handleEstimate } from "./tools/estimate.js";
-import { balanceSchema, balanceDescription, handleBalance } from "./tools/balance.js";
+import {
+  estimateSchema,
+  estimateDescription,
+  handleEstimate,
+} from "./tools/estimate.js";
+import {
+  balanceSchema,
+  balanceDescription,
+  handleBalance,
+} from "./tools/balance.js";
 import {
   listSessionsSchema,
   listSessionsDescription,
@@ -20,6 +36,15 @@ import {
   createSessionSchema,
   createSessionDescription,
   handleCreateSession,
+  getSessionSchema,
+  getSessionDescription,
+  handleGetSession,
+  updateSessionSchema,
+  updateSessionDescription,
+  handleUpdateSession,
+  refreshSessionSchema,
+  refreshSessionDescription,
+  handleRefreshSession,
   validateSessionSchema,
   validateSessionDescription,
   handleValidateSession,
@@ -37,27 +62,39 @@ function createServer(config: Config): McpServer {
   });
 
   // Register tools
-  server.tool("alterlab_scrape", scrapeDescription, scrapeSchema.shape, (params) =>
-    handleScrape(client, params as any)
+  server.tool(
+    "alterlab_scrape",
+    scrapeDescription,
+    scrapeSchema.shape,
+    (params) => handleScrape(client, params as any),
   );
 
-  server.tool("alterlab_extract", extractDescription, extractSchema.shape, (params) =>
-    handleExtract(client, params as any)
+  server.tool(
+    "alterlab_extract",
+    extractDescription,
+    extractSchema.shape,
+    (params) => handleExtract(client, params as any),
   );
 
   server.tool(
     "alterlab_screenshot",
     screenshotDescription,
     screenshotSchema.shape,
-    (params) => handleScreenshot(client, params as any)
+    (params) => handleScreenshot(client, params as any),
   );
 
-  server.tool("alterlab_estimate_cost", estimateDescription, estimateSchema.shape, (params) =>
-    handleEstimate(client, params as any)
+  server.tool(
+    "alterlab_estimate_cost",
+    estimateDescription,
+    estimateSchema.shape,
+    (params) => handleEstimate(client, params as any),
   );
 
-  server.tool("alterlab_check_balance", balanceDescription, balanceSchema.shape, () =>
-    handleBalance(client)
+  server.tool(
+    "alterlab_check_balance",
+    balanceDescription,
+    balanceSchema.shape,
+    () => handleBalance(client),
   );
 
   // Session management tools
@@ -65,28 +102,49 @@ function createServer(config: Config): McpServer {
     "alterlab_list_sessions",
     listSessionsDescription,
     listSessionsSchema.shape,
-    () => handleListSessions(client)
+    () => handleListSessions(client),
   );
 
   server.tool(
     "alterlab_create_session",
     createSessionDescription,
     createSessionSchema.shape,
-    (params) => handleCreateSession(client, params as any)
+    (params) => handleCreateSession(client, params as any),
+  );
+
+  server.tool(
+    "alterlab_get_session",
+    getSessionDescription,
+    getSessionSchema.shape,
+    (params) => handleGetSession(client, params as any),
+  );
+
+  server.tool(
+    "alterlab_update_session",
+    updateSessionDescription,
+    updateSessionSchema.shape,
+    (params) => handleUpdateSession(client, params as any),
+  );
+
+  server.tool(
+    "alterlab_refresh_session",
+    refreshSessionDescription,
+    refreshSessionSchema.shape,
+    (params) => handleRefreshSession(client, params as any),
   );
 
   server.tool(
     "alterlab_validate_session",
     validateSessionDescription,
     validateSessionSchema.shape,
-    (params) => handleValidateSession(client, params as any)
+    (params) => handleValidateSession(client, params as any),
   );
 
   server.tool(
     "alterlab_delete_session",
     deleteSessionDescription,
     deleteSessionSchema.shape,
-    (params) => handleDeleteSession(client, params as any)
+    (params) => handleDeleteSession(client, params as any),
   );
 
   return server;

--- a/src/tools/sessions.ts
+++ b/src/tools/sessions.ts
@@ -2,7 +2,14 @@ import { z } from "zod";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { AlterLabClient } from "../client.js";
 import { type ApiError, formatErrorResult } from "../errors.js";
-import { formatSessionListResponse, formatSessionCreateResponse, formatSessionValidateResponse } from "../format.js";
+import {
+  formatSessionListResponse,
+  formatSessionCreateResponse,
+  formatSessionDetailResponse,
+  formatSessionUpdateResponse,
+  formatSessionRefreshResponse,
+  formatSessionValidateResponse,
+} from "../format.js";
 
 // ============================================================================
 // List Sessions
@@ -17,7 +24,7 @@ export const listSessionsDescription =
   "Use the returned session_id with alterlab_scrape to scrape authenticated pages.";
 
 export async function handleListSessions(
-  client: AlterLabClient
+  client: AlterLabClient,
 ): Promise<CallToolResult> {
   try {
     const response = await client.listSessions();
@@ -41,7 +48,9 @@ export const createSessionSchema = z.object({
     .string()
     .min(1)
     .max(100)
-    .describe("Human-readable name for this session (e.g., 'My Amazon Account')"),
+    .describe(
+      "Human-readable name for this session (e.g., 'My Amazon Account')",
+    ),
   domain: z
     .string()
     .min(1)
@@ -50,7 +59,7 @@ export const createSessionSchema = z.object({
     .record(z.string(), z.string())
     .describe(
       "Cookie key-value pairs for authentication " +
-      "(e.g., {\"session-id\": \"abc123\", \"session-token\": \"xyz789\"})"
+        '(e.g., {"session-id": "abc123", "session-token": "xyz789"})',
     ),
   user_agent: z
     .string()
@@ -66,7 +75,7 @@ export const createSessionDescription =
 
 export async function handleCreateSession(
   client: AlterLabClient,
-  params: z.infer<typeof createSessionSchema>
+  params: z.infer<typeof createSessionSchema>,
 ): Promise<CallToolResult> {
   try {
     const response = await client.createSession({
@@ -91,10 +100,7 @@ export async function handleCreateSession(
 // ============================================================================
 
 export const validateSessionSchema = z.object({
-  session_id: z
-    .string()
-    .uuid()
-    .describe("UUID of the session to validate"),
+  session_id: z.string().uuid().describe("UUID of the session to validate"),
 });
 
 export const validateSessionDescription =
@@ -104,7 +110,7 @@ export const validateSessionDescription =
 
 export async function handleValidateSession(
   client: AlterLabClient,
-  params: z.infer<typeof validateSessionSchema>
+  params: z.infer<typeof validateSessionSchema>,
 ): Promise<CallToolResult> {
   try {
     const response = await client.validateSession(params.session_id);
@@ -122,14 +128,145 @@ export async function handleValidateSession(
 }
 
 // ============================================================================
+// Get Session
+// ============================================================================
+
+export const getSessionSchema = z.object({
+  session_id: z.string().uuid().describe("UUID of the session to retrieve"),
+});
+
+export const getSessionDescription =
+  "Get detailed information about a specific stored session. " +
+  "Returns session status, cookie names, usage statistics (total requests, " +
+  "success rate), expiry info, and notes. Use this to inspect a session " +
+  "before deciding to validate, refresh, or delete it.";
+
+export async function handleGetSession(
+  client: AlterLabClient,
+  params: z.infer<typeof getSessionSchema>,
+): Promise<CallToolResult> {
+  try {
+    const response = await client.getSession(params.session_id);
+    return {
+      content: [{ type: "text", text: formatSessionDetailResponse(response) }],
+    };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error);
+    }
+    return formatErrorResult(error as Error);
+  }
+}
+
+// ============================================================================
+// Update Session
+// ============================================================================
+
+export const updateSessionSchema = z.object({
+  session_id: z.string().uuid().describe("UUID of the session to update"),
+  name: z
+    .string()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe("New name for the session"),
+  cookies: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe(
+      "New cookie key-value pairs — replaces ALL existing cookies " +
+        '(e.g., {"session-id": "new123", "session-token": "newxyz"})',
+    ),
+  headers: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe("New custom headers — replaces ALL existing headers"),
+  expires_at: z
+    .string()
+    .optional()
+    .describe(
+      "New expiration date in ISO 8601 format (e.g., '2026-12-31T23:59:59Z')",
+    ),
+  notes: z
+    .string()
+    .max(1000)
+    .optional()
+    .describe("Notes or description for this session"),
+});
+
+export const updateSessionDescription =
+  "Update a stored session's properties. You can change the name, rotate " +
+  "cookies, update custom headers, set a new expiration, or add notes. " +
+  "When cookies are provided, they replace ALL existing cookies (not merged). " +
+  "Use this instead of delete+recreate when you need to rotate credentials.";
+
+export async function handleUpdateSession(
+  client: AlterLabClient,
+  params: z.infer<typeof updateSessionSchema>,
+): Promise<CallToolResult> {
+  try {
+    const { session_id, ...updateFields } = params;
+    const response = await client.updateSession(session_id, updateFields);
+    return {
+      content: [{ type: "text", text: formatSessionUpdateResponse(response) }],
+    };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error);
+    }
+    return formatErrorResult(error as Error);
+  }
+}
+
+// ============================================================================
+// Refresh Session
+// ============================================================================
+
+export const refreshSessionSchema = z.object({
+  session_id: z.string().uuid().describe("UUID of the session to refresh"),
+  cookies: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe(
+      "New cookie key-value pairs to replace the old ones. " +
+        "If omitted, only failure counters are reset.",
+    ),
+  headers: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe("Updated custom headers to include with the session"),
+});
+
+export const refreshSessionDescription =
+  "Refresh a session by rotating its cookies and resetting failure counters. " +
+  "This is the preferred way to update cookies after re-authenticating in " +
+  "your browser. The session status is reset to active. If cookies are " +
+  "omitted, only the failure counters are reset.";
+
+export async function handleRefreshSession(
+  client: AlterLabClient,
+  params: z.infer<typeof refreshSessionSchema>,
+): Promise<CallToolResult> {
+  try {
+    const { session_id, ...refreshFields } = params;
+    const response = await client.refreshSession(session_id, refreshFields);
+    return {
+      content: [{ type: "text", text: formatSessionRefreshResponse(response) }],
+    };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error);
+    }
+    return formatErrorResult(error as Error);
+  }
+}
+
+// ============================================================================
 // Delete Session
 // ============================================================================
 
 export const deleteSessionSchema = z.object({
-  session_id: z
-    .string()
-    .uuid()
-    .describe("UUID of the session to delete"),
+  session_id: z.string().uuid().describe("UUID of the session to delete"),
 });
 
 export const deleteSessionDescription =
@@ -138,7 +275,7 @@ export const deleteSessionDescription =
 
 export async function handleDeleteSession(
   client: AlterLabClient,
-  params: z.infer<typeof deleteSessionSchema>
+  params: z.infer<typeof deleteSessionSchema>,
 ): Promise<CallToolResult> {
   try {
     await client.deleteSession(params.session_id);

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,39 @@ export interface SessionValidateResponse {
   reason?: string;
 }
 
+export interface SessionDetailResponse {
+  id: string;
+  name: string;
+  domain: string;
+  cookie_names: string[];
+  header_names?: string[];
+  status: string;
+  expires_at?: string;
+  last_validated_at?: string;
+  consecutive_failures: number;
+  last_used_at?: string;
+  total_requests: number;
+  successful_requests: number;
+  success_rate: number;
+  notes?: string;
+  expiry_status?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SessionUpdateRequest {
+  name?: string;
+  cookies?: Record<string, string>;
+  headers?: Record<string, string>;
+  expires_at?: string;
+  notes?: string;
+}
+
+export interface SessionRefreshRequest {
+  cookies?: Record<string, string>;
+  headers?: Record<string, string>;
+}
+
 // ============================================================================
 // API Response Types
 // ============================================================================


### PR DESCRIPTION
## Summary
- Add 3 missing session MCP tools: `alterlab_get_session`, `alterlab_update_session`, `alterlab_refresh_session`
- Completes the session tool surface to match all 7 API operations (was 4/7, now 7/7)
- Follows existing patterns: Zod schemas, error handling, LLM-optimized formatters

Closes RapierCraftStudios/AlterLab#3650

## Changes
- `src/types.ts` — New interfaces: `SessionDetailResponse`, `SessionUpdateRequest`, `SessionRefreshRequest`
- `src/client.ts` — New methods: `getSession()`, `updateSession()`, `refreshSession()`
- `src/tools/sessions.ts` — 3 new tool handlers with Zod schemas
- `src/format.ts` — 3 new formatters for detail, update, and refresh responses
- `src/index.ts` — Register the 3 new tools in the MCP server