### PR TITLE
Fix: Sync stale T3/T3.5/T4 tier prices with shared/pricing.py

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -133,7 +133,7 @@ export function formatEstimateResponse(estimate: CostEstimate): string {
     `- Estimated tier: **${tierName}** (tier ${estimate.estimated_tier})\n` +
     `- Estimated cost: **${tierPrice}** per request\n` +
     `- Confidence: ${estimate.confidence}\n` +
-    `- Max possible cost: tier 4 (browser) = $0.001/req\n\n` +
+    `- Max possible cost: tier 4 (browser) = $0.004/req\n\n` +
     `${estimate.reasoning}`
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -192,8 +192,8 @@ export const TIER_NAMES: Record<string, string> = {
 export const TIER_PRICES: Record<string, string> = {
   "1": "$0.0002",
   "2": "$0.0003",
-  "3": "$0.0005",
-  "3.5": "$0.0007",
-  "4": "$0.001",
+  "3": "$0.002",
+  "3.5": "$0.0025",
+  "4": "$0.004",
   "5": "$0.02",
 };


### PR DESCRIPTION
## Summary

- Tier prices in \`src/types.ts\` were 4-5x lower than actual prices after the AlterLab pricing refactor (PR #5945)
- Updated T3 \$0.0005→\$0.002, T3.5 \$0.0007→\$0.0025, T4 \$0.001→\$0.004
- Fixed hardcoded stale price string in \`src/format.ts\` (max cost display in cost estimates)

Closes #57

## Changes

- \`src/types.ts\` — \`TIER_PRICES\` constant updated for T3/T3.5/T4
- \`src/format.ts:136\` — Hardcoded max cost string updated from \$0.001/req to \$0.004/req