### PR TITLE
Fix: update render_js descriptions — no longer a credit add-on

### DIFF
--- a/src/tools/estimate.ts
+++ b/src/tools/estimate.ts
@@ -13,7 +13,9 @@ export const estimateSchema = z.object({
   render_js: z
     .boolean()
     .default(false)
-    .describe("Include JS rendering cost (+3 credits)"),
+    .describe(
+      "Enable JS rendering (forces Tier 4 minimum — no separate add-on charge)",
+    ),
   use_proxy: z
     .boolean()
     .default(false)
@@ -27,7 +29,7 @@ export const estimateDescription =
 
 export async function handleEstimate(
   client: AlterLabClient,
-  params: z.infer<typeof estimateSchema>
+  params: z.infer<typeof estimateSchema>,
 ): Promise<CallToolResult> {
   try {
     const estimate = await client.estimate({

--- a/src/tools/extract.ts
+++ b/src/tools/extract.ts
@@ -7,29 +7,39 @@ import { formatExtractResponse } from "../format.js";
 export const extractSchema = z.object({
   url: z.string().url().describe("URL to extract structured data from"),
   extraction_profile: z
-    .enum(["auto", "product", "article", "job_posting", "faq", "recipe", "event"])
+    .enum([
+      "auto",
+      "product",
+      "article",
+      "job_posting",
+      "faq",
+      "recipe",
+      "event",
+    ])
     .default("auto")
     .describe(
       "Pre-defined extraction profile. 'product' extracts price/title/reviews, " +
-        "'article' extracts title/author/body, etc. 'auto' detects the page type"
+        "'article' extracts title/author/body, etc. 'auto' detects the page type",
     ),
   extraction_schema: z
     .record(z.unknown())
     .optional()
     .describe(
       "Custom JSON Schema for extraction. Fields are mapped from page content. " +
-        "Overrides extraction_profile when provided"
+        "Overrides extraction_profile when provided",
     ),
   extraction_prompt: z
     .string()
     .optional()
     .describe(
-      "Natural language instructions for extraction (e.g., 'Extract all product prices and ratings')"
+      "Natural language instructions for extraction (e.g., 'Extract all product prices and ratings')",
     ),
   render_js: z
     .boolean()
     .default(false)
-    .describe("Render JavaScript using headless browser (+3 credits)"),
+    .describe(
+      "Render JavaScript using headless browser (forces Tier 4 minimum — no separate add-on charge)",
+    ),
   use_proxy: z
     .boolean()
     .default(false)
@@ -44,7 +54,7 @@ export const extractDescription =
 
 export async function handleExtract(
   client: AlterLabClient,
-  params: z.infer<typeof extractSchema>
+  params: z.infer<typeof extractSchema>,
 ): Promise<CallToolResult> {
   try {
     const response = await client.scrape({

--- a/src/tools/scrape.ts
+++ b/src/tools/scrape.ts
@@ -9,7 +9,9 @@ export const scrapeSchema = z.object({
   mode: z
     .enum(["auto", "html", "js", "pdf", "ocr"])
     .default("auto")
-    .describe("Scraping mode: auto (recommended), html, js (headless browser), pdf, or ocr"),
+    .describe(
+      "Scraping mode: auto (recommended), html, js (headless browser), pdf, or ocr",
+    ),
   formats: z
     .array(z.enum(["text", "json", "html", "markdown"]))
     .default(["markdown"])
@@ -17,19 +19,27 @@ export const scrapeSchema = z.object({
   render_js: z
     .boolean()
     .default(false)
-    .describe("Render JavaScript using headless browser (+3 credits). Required for JS-heavy sites"),
+    .describe(
+      "Render JavaScript using headless browser (forces Tier 4 minimum — no separate add-on charge). Required for JS-heavy sites",
+    ),
   use_proxy: z
     .boolean()
     .default(false)
-    .describe("Route through premium proxy (+1 credit). Helps bypass geo-restrictions and anti-bot"),
+    .describe(
+      "Route through premium proxy (+1 credit). Helps bypass geo-restrictions and anti-bot",
+    ),
   proxy_country: z
     .string()
     .optional()
-    .describe("ISO country code for geo-targeting (e.g., 'US', 'DE'). Requires use_proxy=true"),
+    .describe(
+      "ISO country code for geo-targeting (e.g., 'US', 'DE'). Requires use_proxy=true",
+    ),
   wait_for: z
     .string()
     .optional()
-    .describe("CSS selector to wait for before extracting content (e.g., '#main-content')"),
+    .describe(
+      "CSS selector to wait for before extracting content (e.g., '#main-content')",
+    ),
   timeout: z
     .number()
     .min(1)
@@ -46,16 +56,16 @@ export const scrapeSchema = z.object({
     .optional()
     .describe(
       "UUID of a stored session for authenticated scraping. " +
-      "Use alterlab_list_sessions to find available sessions. " +
-      "The session's cookies will be injected into the request."
+        "Use alterlab_list_sessions to find available sessions. " +
+        "The session's cookies will be injected into the request.",
     ),
   cookies: z
     .record(z.string(), z.string())
     .optional()
     .describe(
       "Inline cookies as key-value pairs for authenticated scraping " +
-      "(e.g., {\"session_token\": \"abc123\"}). " +
-      "Use this for one-off requests; use session_id for reusable sessions."
+        '(e.g., {"session_token": "abc123"}). ' +
+        "Use this for one-off requests; use session_id for reusable sessions.",
     ),
 });
 
@@ -69,7 +79,7 @@ export const scrapeDescription =
 
 export async function handleScrape(
   client: AlterLabClient,
-  params: z.infer<typeof scrapeSchema>
+  params: z.infer<typeof scrapeSchema>,
 ): Promise<CallToolResult> {
   try {
     const response = await client.scrape({


### PR DESCRIPTION
## Summary

- Remove stale "+3 credits" add-on language from `render_js` parameter descriptions in all three tool schemas
- Replace with accurate Tier 4 minimum language: "forces Tier 4 minimum — no separate add-on charge"

Closes #58

## Changes

| File | Change |
|------|--------|
| `src/tools/scrape.ts` | Updated `render_js` describe string |
| `src/tools/extract.ts` | Updated `render_js` describe string |
| `src/tools/estimate.ts` | Updated `render_js` describe string |

## Background

`render_js` no longer adds a flat +3 credit surcharge. Since AlterLab API pricing refactor (PR #5945), it forces a Tier 4 minimum — the cost is reflected in the T4 tier price, not as a separate add-on.