### PR TITLE
Feat: Full API parity — crawl, search, map, batch tools

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2,7 +2,20 @@ import { type Config } from "./config.js";
 import { type ApiError } from "./errors.js";
 import {
   type BalanceResponse,
+  type BatchRequest,
+  type BatchResponse,
+  type BatchStatusResponse,
   type CostEstimate,
+  type CrawlCancelResponse,
+  type CrawlRequest,
+  type CrawlResponse,
+  type CrawlStatusResponse,
+  type ExtractRequest,
+  type ExtractResponse,
+  type MapRequest,
+  type MapResponse,
+  type SearchRequest,
+  type SearchResponse,
   type Session,
   type SessionCreateRequest,
   type SessionCreateResponse,
@@ -157,6 +170,65 @@ export class AlterLabClient {
       `/api/v1/sessions/${sessionId}`,
     );
   }
+
+  // ============================================================================
+  // Crawl methods
+  // ============================================================================
+
+  async startCrawl(params: CrawlRequest): Promise<CrawlResponse> {
+    return this.request<CrawlResponse>("POST", "/api/v1/crawl", params);
+  }
+
+  async getCrawlStatus(crawlId: string): Promise<CrawlStatusResponse> {
+    return this.request<CrawlStatusResponse>("GET", `/api/v1/crawl/${crawlId}`);
+  }
+
+  async cancelCrawl(crawlId: string): Promise<CrawlCancelResponse> {
+    return this.request<CrawlCancelResponse>(
+      "DELETE",
+      `/api/v1/crawl/${crawlId}`,
+    );
+  }
+
+  // ============================================================================
+  // Search method
+  // ============================================================================
+
+  async search(params: SearchRequest): Promise<SearchResponse> {
+    return this.request<SearchResponse>("POST", "/api/v1/search", params);
+  }
+
+  // ============================================================================
+  // Map method
+  // ============================================================================
+
+  async map(params: MapRequest): Promise<MapResponse> {
+    return this.request<MapResponse>("POST", "/api/v1/map", params);
+  }
+
+  // ============================================================================
+  // Extract method (standalone — bring your own content)
+  // ============================================================================
+
+  async extract(params: ExtractRequest): Promise<ExtractResponse> {
+    return this.request<ExtractResponse>("POST", "/api/v1/extract", params);
+  }
+
+  // ============================================================================
+  // Batch methods
+  // ============================================================================
+
+  async submitBatch(params: BatchRequest): Promise<BatchResponse> {
+    return this.request<BatchResponse>("POST", "/api/v1/batch", params);
+  }
+
+  async getBatchStatus(batchId: string): Promise<BatchStatusResponse> {
+    return this.request<BatchStatusResponse>("GET", `/api/v1/batch/${batchId}`);
+  }
+
+  // ============================================================================
+  // Screenshot fetch helper
+  // ============================================================================
 
   async fetchScreenshotAsBase64(screenshotUrl: string): Promise<string> {
     // screenshot_url is a relative path like /downloads/screenshots/...

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ export function loadConfig(): Config {
       "Error: ALTERLAB_API_KEY environment variable is required.\n\n" +
         "Get your API key at https://alterlab.io/dashboard/api-keys\n\n" +
         "Then add it to your MCP config:\n" +
-        '  "env": { "ALTERLAB_API_KEY": "sk_live_..." }'
+        '  "env": { "ALTERLAB_API_KEY": "sk_live_..." }',
     );
     process.exit(1);
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -8,7 +8,7 @@ export interface ApiError {
 
 export function formatErrorResult(
   error: ApiError | Error,
-  context?: { url?: string }
+  context?: { url?: string },
 ): CallToolResult {
   if (error instanceof Error) {
     // Network/timeout errors
@@ -40,7 +40,11 @@ export function formatErrorResult(
     };
   }
 
-  const url = error.url ? ` for ${error.url}` : context?.url ? ` for ${context.url}` : "";
+  const url = error.url
+    ? ` for ${error.url}`
+    : context?.url
+      ? ` for ${context.url}`
+      : "";
   const detail = error.detail || "Unknown error";
 
   switch (error.status) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,31 @@ import {
   handleBalance,
 } from "./tools/balance.js";
 import {
+  crawlSchema,
+  crawlDescription,
+  handleCrawl,
+  crawlStatusSchema,
+  crawlStatusDescription,
+  handleCrawlStatus,
+  crawlCancelSchema,
+  crawlCancelDescription,
+  handleCrawlCancel,
+} from "./tools/crawl.js";
+import {
+  searchSchema,
+  searchDescription,
+  handleSearch,
+} from "./tools/search.js";
+import { mapSchema, mapDescription, handleMap } from "./tools/map.js";
+import {
+  batchSchema,
+  batchDescription,
+  handleBatch,
+  batchStatusSchema,
+  batchStatusDescription,
+  handleBatchStatus,
+} from "./tools/batch.js";
+import {
   listSessionsSchema,
   listSessionsDescription,
   handleListSessions,
@@ -58,7 +83,7 @@ function createServer(config: Config): McpServer {
 
   const server = new McpServer({
     name: "alterlab",
-    version: "1.1.1",
+    version: "1.2.0",
   });
 
   // Register tools
@@ -95,6 +120,50 @@ function createServer(config: Config): McpServer {
     balanceDescription,
     balanceSchema.shape,
     () => handleBalance(client),
+  );
+
+  // Crawl tools
+  server.tool("alterlab_crawl", crawlDescription, crawlSchema.shape, (params) =>
+    handleCrawl(client, params as any),
+  );
+
+  server.tool(
+    "alterlab_crawl_status",
+    crawlStatusDescription,
+    crawlStatusSchema.shape,
+    (params) => handleCrawlStatus(client, params as any),
+  );
+
+  server.tool(
+    "alterlab_crawl_cancel",
+    crawlCancelDescription,
+    crawlCancelSchema.shape,
+    (params) => handleCrawlCancel(client, params as any),
+  );
+
+  // Search tool
+  server.tool(
+    "alterlab_search",
+    searchDescription,
+    searchSchema.shape,
+    (params) => handleSearch(client, params as any),
+  );
+
+  // Map tool
+  server.tool("alterlab_map", mapDescription, mapSchema.shape, (params) =>
+    handleMap(client, params as any),
+  );
+
+  // Batch tools
+  server.tool("alterlab_batch", batchDescription, batchSchema.shape, (params) =>
+    handleBatch(client, params as any),
+  );
+
+  server.tool(
+    "alterlab_batch_status",
+    batchStatusDescription,
+    batchStatusSchema.shape,
+    (params) => handleBatchStatus(client, params as any),
   );
 
   // Session management tools

--- a/src/tools/balance.ts
+++ b/src/tools/balance.ts
@@ -12,7 +12,7 @@ export const balanceDescription =
   "No parameters required — uses your API key for identification.";
 
 export async function handleBalance(
-  client: AlterLabClient
+  client: AlterLabClient,
 ): Promise<CallToolResult> {
   try {
     const balance = await client.getBalance();

--- a/src/tools/batch.ts
+++ b/src/tools/batch.ts
@@ -1,0 +1,202 @@
+import { z } from "zod";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { AlterLabClient } from "../client.js";
+import { type ApiError, formatErrorResult } from "../errors.js";
+
+// ============================================================================
+// Submit Batch
+// ============================================================================
+
+const batchItemSchema = z.object({
+  url: z.string().url().describe("URL to scrape"),
+  mode: z
+    .enum(["auto", "html", "js", "pdf", "ocr"])
+    .default("auto")
+    .optional()
+    .describe("Scraping mode for this URL"),
+  formats: z
+    .array(z.enum(["text", "json", "json_v2", "html", "markdown", "rag"]))
+    .optional()
+    .describe("Output formats for this URL (overrides batch-level formats)"),
+  extraction_schema: z
+    .record(z.unknown())
+    .optional()
+    .describe("JSON schema for structured extraction from this URL"),
+  render_js: z.boolean().optional().describe("Render JavaScript for this URL"),
+  use_proxy: z.boolean().optional().describe("Use premium proxy for this URL"),
+  timeout: z
+    .number()
+    .int()
+    .min(1)
+    .max(300)
+    .default(90)
+    .optional()
+    .describe("Timeout in seconds for this URL"),
+  wait_for: z
+    .string()
+    .optional()
+    .describe("CSS selector to wait for before extracting content"),
+  cache: z
+    .boolean()
+    .default(false)
+    .optional()
+    .describe("Enable caching for this URL"),
+});
+
+export const batchSchema = z.object({
+  urls: z
+    .array(batchItemSchema)
+    .min(1)
+    .max(100)
+    .describe("List of URLs to scrape (max 100)"),
+  webhook_url: z
+    .string()
+    .url()
+    .optional()
+    .describe(
+      "Webhook URL to receive batch.completed event when all jobs finish",
+    ),
+});
+
+export const batchDescription =
+  "Submit up to 100 URLs for parallel scraping in a single batch request. " +
+  "Returns a batch_id immediately — use alterlab_batch_status to poll results. " +
+  "Each URL can have its own mode, formats, extraction_schema, and options. " +
+  "Credits are pre-debited based on estimated cost; unused credits are refunded on completion. " +
+  "Use this instead of calling alterlab_scrape repeatedly for multiple URLs.";
+
+export async function handleBatch(
+  client: AlterLabClient,
+  params: z.infer<typeof batchSchema>,
+): Promise<CallToolResult> {
+  try {
+    const response = await client.submitBatch({
+      urls: params.urls.map((item) => ({
+        url: item.url,
+        mode: item.mode,
+        formats: item.formats,
+        extraction_schema: item.extraction_schema,
+        timeout: item.timeout,
+        wait_for: item.wait_for,
+        cache: item.cache,
+        advanced: {
+          render_js: item.render_js,
+          use_proxy: item.use_proxy,
+        },
+      })),
+      webhook_url: params.webhook_url,
+    });
+
+    const text =
+      `**Batch Submitted**\n\n` +
+      `- Batch ID: \`${response.batch_id}\`\n` +
+      `- Status: ${response.status}\n` +
+      `- Total URLs: ${response.total_urls}\n` +
+      `- Estimated credits: ${response.estimated_credits}\n\n` +
+      `Use \`alterlab_batch_status\` with batch_id \`${response.batch_id}\` to poll for results.\n` +
+      `Individual job IDs: ${(response.job_ids ?? []).slice(0, 5).join(", ")}${(response.job_ids ?? []).length > 5 ? ` ... and ${(response.job_ids ?? []).length - 5} more` : ""}`;
+
+    return { content: [{ type: "text", text }] };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error);
+    }
+    return formatErrorResult(error as Error);
+  }
+}
+
+// ============================================================================
+// Batch Status
+// ============================================================================
+
+export const batchStatusSchema = z.object({
+  batch_id: z.string().describe("Batch ID returned by alterlab_batch"),
+});
+
+export const batchStatusDescription =
+  "Poll the status and results of a submitted batch. " +
+  "Call this after alterlab_batch to check progress and retrieve scraped content. " +
+  "Status values: processing, completed, failed, partially_failed. " +
+  "When completed, results contains the content for each URL.";
+
+export async function handleBatchStatus(
+  client: AlterLabClient,
+  params: z.infer<typeof batchStatusSchema>,
+): Promise<CallToolResult> {
+  try {
+    const response = await client.getBatchStatus(params.batch_id);
+    const text = formatBatchStatusResponse(response, params.batch_id);
+    return { content: [{ type: "text", text }] };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error, { url: params.batch_id });
+    }
+    return formatErrorResult(error as Error, { url: params.batch_id });
+  }
+}
+
+function formatBatchStatusResponse(response: unknown, batchId: string): string {
+  const r = response as Record<string, unknown>;
+  const status = String(r.status ?? "unknown");
+  const totalUrls = Number(r.total_urls ?? 0);
+  const completedCount = Number(r.completed ?? 0);
+  const failedCount = Number(r.failed ?? 0);
+  const creditsUsed = r.credits_used ? Number(r.credits_used) : null;
+  const items = Array.isArray(r.items) ? r.items : [];
+
+  const parts: string[] = [
+    `**Batch Status: ${status.toUpperCase()}**\n`,
+    `- Batch ID: \`${batchId}\``,
+    `- Total URLs: ${totalUrls}`,
+    `- Completed: ${completedCount}`,
+    `- Failed: ${failedCount}`,
+  ];
+
+  if (creditsUsed !== null) {
+    parts.push(`- Credits used: ${creditsUsed}`);
+  }
+
+  if (status === "processing") {
+    const remaining = totalUrls - completedCount - failedCount;
+    parts.push(
+      `\n${remaining} URL${remaining !== 1 ? "s" : ""} still processing. Poll again with \`alterlab_batch_status\`.`,
+    );
+  } else if (items.length > 0) {
+    parts.push("\n**Results:**\n");
+    for (const item of items) {
+      const it = item as Record<string, unknown>;
+      const url = String(it.url ?? "");
+      const itemStatus = String(it.status ?? "");
+      const error = it.error ? ` (${String(it.error)})` : "";
+
+      let contentPreview = "";
+      const result = it.result as Record<string, unknown> | undefined;
+      if (result) {
+        const content = result.content;
+        if (typeof content === "object" && content !== null) {
+          const contentMap = content as Record<string, string>;
+          const text =
+            contentMap.markdown || contentMap.text || contentMap.html || "";
+          if (text) {
+            contentPreview = ` — "${text.slice(0, 80)}${text.length > 80 ? "..." : ""}"`;
+          }
+        } else if (typeof content === "string") {
+          contentPreview = ` — "${content.slice(0, 80)}${content.length > 80 ? "..." : ""}"`;
+        }
+      }
+
+      parts.push(`- [${itemStatus}] ${url}${error}${contentPreview}`);
+    }
+  }
+
+  return parts.join("\n");
+}
+
+function isApiError(error: unknown): error is ApiError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof (error as ApiError).status === "number"
+  );
+}

--- a/src/tools/crawl.ts
+++ b/src/tools/crawl.ts
@@ -1,0 +1,259 @@
+import { z } from "zod";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { AlterLabClient } from "../client.js";
+import { type ApiError, formatErrorResult } from "../errors.js";
+
+// ============================================================================
+// Start Crawl
+// ============================================================================
+
+export const crawlSchema = z.object({
+  url: z.string().url().describe("Start URL for the crawl"),
+  max_pages: z
+    .number()
+    .int()
+    .min(1)
+    .max(100000)
+    .default(50)
+    .describe("Maximum number of pages to scrape"),
+  max_depth: z
+    .number()
+    .int()
+    .min(0)
+    .max(20)
+    .default(3)
+    .describe(
+      "Maximum link-following depth from start URL (0 = start page only)",
+    ),
+  include_patterns: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Glob patterns — only scrape URLs whose path matches at least one (e.g., ['/blog/*', '/docs/*'])",
+    ),
+  exclude_patterns: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Glob patterns — skip URLs whose path matches any (e.g., ['/tag/*', '/author/*'])",
+    ),
+  sitemap: z
+    .enum(["include", "skip", "only"])
+    .default("include")
+    .describe(
+      "Sitemap mode: include (default), skip (link extraction only), only (sitemap URLs only)",
+    ),
+  formats: z
+    .array(z.enum(["text", "json", "json_v2", "html", "markdown"]))
+    .optional()
+    .describe("Output formats for each scraped page"),
+  extraction_schema: z
+    .record(z.unknown())
+    .optional()
+    .describe("JSON schema for structured extraction on each page"),
+  render_js: z
+    .union([z.boolean(), z.literal("auto")])
+    .default(false)
+    .describe(
+      "Render JavaScript on crawled pages. true=always (Tier 4), false=never, auto=smart detection per page",
+    ),
+  use_proxy: z
+    .boolean()
+    .default(false)
+    .describe("Route all crawl requests through premium proxy"),
+  max_concurrency: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .default(10)
+    .describe("Maximum concurrent pages to scrape simultaneously"),
+  respect_robots: z
+    .boolean()
+    .default(true)
+    .describe("Respect robots.txt rules for the target domain"),
+  include_subdomains: z
+    .boolean()
+    .default(false)
+    .describe("Include links to subdomains during discovery"),
+  webhook_url: z
+    .string()
+    .url()
+    .optional()
+    .describe("Webhook URL to notify on crawl completion"),
+});
+
+export const crawlDescription =
+  "Start an asynchronous crawl of an entire website. " +
+  "Discovers URLs via sitemap parsing and link extraction, then scrapes each page. " +
+  "Returns a crawl_id immediately — use alterlab_crawl_status to poll results. " +
+  "Use include_patterns/exclude_patterns to scope the crawl to specific sections. " +
+  "Use render_js='auto' for mixed sites to save 30-60% vs always rendering. " +
+  "Supports extraction_schema to extract structured data from every page.";
+
+export async function handleCrawl(
+  client: AlterLabClient,
+  params: z.infer<typeof crawlSchema>,
+): Promise<CallToolResult> {
+  try {
+    const response = await client.startCrawl({
+      url: params.url,
+      max_pages: params.max_pages,
+      max_depth: params.max_depth,
+      include_patterns: params.include_patterns,
+      exclude_patterns: params.exclude_patterns,
+      sitemap: params.sitemap,
+      formats: params.formats,
+      extraction_schema: params.extraction_schema,
+      max_concurrency: params.max_concurrency,
+      respect_robots: params.respect_robots,
+      include_subdomains: params.include_subdomains,
+      webhook_url: params.webhook_url,
+      advanced: {
+        render_js: params.render_js,
+        use_proxy: params.use_proxy,
+      },
+    });
+
+    const text =
+      `**Crawl Started**\n\n` +
+      `- Crawl ID: \`${response.crawl_id}\`\n` +
+      `- Status: ${response.status}\n` +
+      `- Start URL: ${response.url}\n` +
+      `- Max pages: ${params.max_pages}\n` +
+      `- Max depth: ${params.max_depth}\n\n` +
+      `Use \`alterlab_crawl_status\` with crawl_id \`${response.crawl_id}\` to poll for results.\n` +
+      `Crawls run asynchronously — check back after a few minutes for large sites.`;
+
+    return { content: [{ type: "text", text }] };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error, { url: params.url });
+    }
+    return formatErrorResult(error as Error, { url: params.url });
+  }
+}
+
+// ============================================================================
+// Crawl Status (poll)
+// ============================================================================
+
+export const crawlStatusSchema = z.object({
+  crawl_id: z.string().describe("Crawl ID returned by alterlab_crawl"),
+});
+
+export const crawlStatusDescription =
+  "Poll the status and results of an ongoing or completed crawl. " +
+  "Call this after alterlab_crawl to check progress and retrieve scraped pages. " +
+  "Status values: queued, running, completed, failed, cancelled. " +
+  "When completed, results contains the scraped page content.";
+
+export async function handleCrawlStatus(
+  client: AlterLabClient,
+  params: z.infer<typeof crawlStatusSchema>,
+): Promise<CallToolResult> {
+  try {
+    const response = await client.getCrawlStatus(params.crawl_id);
+    const text = formatCrawlStatusResponse(response);
+    return { content: [{ type: "text", text }] };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error, { url: params.crawl_id });
+    }
+    return formatErrorResult(error as Error, { url: params.crawl_id });
+  }
+}
+
+// ============================================================================
+// Cancel Crawl
+// ============================================================================
+
+export const crawlCancelSchema = z.object({
+  crawl_id: z.string().describe("Crawl ID to cancel"),
+});
+
+export const crawlCancelDescription =
+  "Cancel an ongoing crawl and refund unused pre-debited credits. " +
+  "Already-scraped pages are kept and available via alterlab_crawl_status. " +
+  "Cancelled crawls cannot be resumed.";
+
+export async function handleCrawlCancel(
+  client: AlterLabClient,
+  params: z.infer<typeof crawlCancelSchema>,
+): Promise<CallToolResult> {
+  try {
+    const response = await client.cancelCrawl(params.crawl_id);
+    const text =
+      `**Crawl Cancelled**\n\n` +
+      `- Crawl ID: \`${params.crawl_id}\`\n` +
+      `- Pages scraped before cancel: ${response.pages_scraped ?? "unknown"}\n` +
+      `- Credits refunded: ${response.credits_refunded ?? 0}\n\n` +
+      `Any pages scraped before cancellation are still available via \`alterlab_crawl_status\`.`;
+
+    return { content: [{ type: "text", text }] };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error, { url: params.crawl_id });
+    }
+    return formatErrorResult(error as Error, { url: params.crawl_id });
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function formatCrawlStatusResponse(response: unknown): string {
+  const r = response as Record<string, unknown>;
+  const status = String(r.status ?? "unknown");
+  const crawlId = String(r.crawl_id ?? "");
+  const url = String(r.url ?? "");
+  const pagesScraped = Number(r.pages_scraped ?? 0);
+  const pagesTotal = r.pages_total ? Number(r.pages_total) : null;
+  const creditsUsed = r.credits_used ? Number(r.credits_used) : null;
+  const results = Array.isArray(r.results) ? r.results : [];
+
+  const parts: string[] = [
+    `**Crawl Status: ${status.toUpperCase()}**\n`,
+    `- Crawl ID: \`${crawlId}\``,
+    `- URL: ${url}`,
+    `- Pages scraped: ${pagesScraped}${pagesTotal ? ` / ${pagesTotal}` : ""}`,
+  ];
+
+  if (creditsUsed !== null) {
+    parts.push(`- Credits used: ${creditsUsed}`);
+  }
+
+  if (status === "running" || status === "queued") {
+    parts.push(
+      "\nCrawl is still in progress. Poll again with `alterlab_crawl_status` to check for updates.",
+    );
+  } else if (status === "completed") {
+    parts.push(`\n**Results** (${results.length} pages):\n`);
+    const preview = results.slice(0, 10);
+    for (const page of preview) {
+      const p = page as Record<string, unknown>;
+      const pageUrl = String(p.url ?? "");
+      const pageStatus = String(p.status ?? "");
+      const title = p.title ? ` — ${String(p.title)}` : "";
+      parts.push(`- [${pageStatus}] ${pageUrl}${title}`);
+    }
+    if (results.length > 10) {
+      parts.push(`... and ${results.length - 10} more pages`);
+    }
+  } else if (status === "failed") {
+    const error = r.error ? String(r.error) : "Unknown error";
+    parts.push(`\n**Error**: ${error}`);
+  }
+
+  return parts.join("\n");
+}
+
+function isApiError(error: unknown): error is ApiError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof (error as ApiError).status === "number"
+  );
+}

--- a/src/tools/extract.ts
+++ b/src/tools/extract.ts
@@ -2,10 +2,19 @@ import { z } from "zod";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { AlterLabClient } from "../client.js";
 import { type ApiError, formatErrorResult } from "../errors.js";
-import { formatExtractResponse } from "../format.js";
 
 export const extractSchema = z.object({
-  url: z.string().url().describe("URL to extract structured data from"),
+  content: z
+    .string()
+    .min(1)
+    .describe(
+      "Raw content to extract from — HTML, text, or markdown. " +
+        "Bring your own pre-fetched content; this endpoint does NOT scrape a URL.",
+    ),
+  content_type: z
+    .enum(["html", "text", "markdown"])
+    .default("html")
+    .describe("Type of the provided content"),
   extraction_profile: z
     .enum([
       "auto",
@@ -16,7 +25,7 @@ export const extractSchema = z.object({
       "recipe",
       "event",
     ])
-    .default("auto")
+    .optional()
     .describe(
       "Pre-defined extraction profile. 'product' extracts price/title/reviews, " +
         "'article' extracts title/author/body, etc. 'auto' detects the page type",
@@ -25,60 +34,129 @@ export const extractSchema = z.object({
     .record(z.unknown())
     .optional()
     .describe(
-      "Custom JSON Schema for extraction. Fields are mapped from page content. " +
+      "Custom JSON Schema for extraction. Fields are mapped from content. " +
         "Overrides extraction_profile when provided",
     ),
   extraction_prompt: z
     .string()
+    .max(2000)
     .optional()
     .describe(
-      "Natural language instructions for extraction (e.g., 'Extract all product prices and ratings')",
+      "Natural language instructions for LLM extraction (e.g., 'Extract all product prices and ratings'). " +
+        "Charged at LLM extraction rate when provided.",
     ),
-  render_js: z
+  formats: z
+    .array(z.enum(["text", "json", "json_v2", "html", "markdown", "rag"]))
+    .default(["json"])
+    .describe(
+      "Output formats for content transformation. 'json' is best for structured extraction.",
+    ),
+  source_url: z
+    .string()
+    .max(2048)
+    .optional()
+    .describe(
+      "Original URL of the content (for context only — not fetched). " +
+        "Helps the extractor understand the content's domain.",
+    ),
+  evidence: z
     .boolean()
     .default(false)
     .describe(
-      "Render JavaScript using headless browser (forces Tier 4 minimum — no separate add-on charge)",
+      "Include field provenance/evidence for extracted fields (which part of the content each field came from)",
     ),
-  use_proxy: z
-    .boolean()
-    .default(false)
-    .describe("Route through premium proxy (+1 credit)"),
 });
 
 export const extractDescription =
-  "Extract structured data from a webpage using pre-defined profiles or custom schemas. " +
+  "Extract structured data from raw HTML, text, or markdown content WITHOUT scraping. " +
+  "Bring your own pre-fetched content. Use this when you already have the page content " +
+  "and want to run AlterLab's extraction pipeline on it. " +
+  "For scraping + extraction in one step, use alterlab_scrape with formats=['json'] instead. " +
   "Profiles: 'product' (price, title, reviews), 'article' (title, author, body), " +
   "'job_posting', 'faq', 'recipe', 'event'. " +
-  "Returns JSON data. Use extraction_prompt for natural language extraction instructions.";
+  "Returns JSON data. Use extraction_prompt for natural language extraction (LLM-powered).";
 
 export async function handleExtract(
   client: AlterLabClient,
   params: z.infer<typeof extractSchema>,
 ): Promise<CallToolResult> {
   try {
-    const response = await client.scrape({
-      url: params.url,
-      formats: ["json"],
-      sync: true,
+    const response = await client.extract({
+      content: params.content,
+      content_type: params.content_type,
       extraction_profile: params.extraction_profile,
       extraction_schema: params.extraction_schema,
       extraction_prompt: params.extraction_prompt,
-      advanced: {
-        render_js: params.render_js,
-        use_proxy: params.use_proxy,
-      },
+      formats: params.formats,
+      source_url: params.source_url,
+      evidence: params.evidence,
     });
 
-    return {
-      content: [{ type: "text", text: formatExtractResponse(response) }],
-    };
+    const text = formatStandaloneExtractResponse(response, params.source_url);
+    return { content: [{ type: "text", text }] };
   } catch (error) {
     if (isApiError(error)) {
-      return formatErrorResult(error, { url: params.url });
+      return formatErrorResult(error, {
+        url: params.source_url ?? "raw content",
+      });
     }
-    return formatErrorResult(error as Error, { url: params.url });
+    return formatErrorResult(error as Error, {
+      url: params.source_url ?? "raw content",
+    });
   }
+}
+
+function formatStandaloneExtractResponse(
+  response: unknown,
+  sourceUrl?: string,
+): string {
+  const r = response as Record<string, unknown>;
+  const extractId = String(r.extract_id ?? "");
+  const creditsUsed = Number(r.credits_used ?? 0);
+  const extractionMethod = String(r.extraction_method ?? "algorithmic");
+  const modelUsed = r.model_used ? String(r.model_used) : null;
+  const formats = r.formats as Record<string, unknown> | undefined;
+
+  const parts: string[] = [];
+
+  if (sourceUrl) {
+    parts.push(`# Extracted: ${sourceUrl}\n`);
+  } else {
+    parts.push(`# Extraction Result\n`);
+  }
+
+  if (formats) {
+    // Prefer json output, then fall through to other formats
+    const jsonData = formats.json || formats.json_v2;
+    const markdown = formats.markdown as string | undefined;
+    const text = formats.text as string | undefined;
+
+    if (jsonData) {
+      parts.push(
+        "```json\n" +
+          (typeof jsonData === "string"
+            ? jsonData
+            : JSON.stringify(jsonData, null, 2)) +
+          "\n```",
+      );
+    } else if (markdown) {
+      parts.push(markdown);
+    } else if (text) {
+      parts.push(text);
+    } else {
+      parts.push("```json\n" + JSON.stringify(formats, null, 2) + "\n```");
+    }
+  }
+
+  parts.push(
+    "\n---\n" +
+      `Extract ID: \`${extractId}\` | ` +
+      `Method: ${extractionMethod}` +
+      (modelUsed ? ` (${modelUsed})` : "") +
+      ` | Credits: ${creditsUsed}`,
+  );
+
+  return parts.join("\n");
 }
 
 function isApiError(error: unknown): error is ApiError {

--- a/src/tools/map.ts
+++ b/src/tools/map.ts
@@ -1,0 +1,165 @@
+import { z } from "zod";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { AlterLabClient } from "../client.js";
+import { type ApiError, formatErrorResult } from "../errors.js";
+
+export const mapSchema = z.object({
+  url: z.string().url().describe("Starting URL for site discovery"),
+  max_pages: z
+    .number()
+    .int()
+    .min(1)
+    .max(50000)
+    .default(500)
+    .describe("Maximum URLs to discover"),
+  max_depth: z
+    .number()
+    .int()
+    .min(0)
+    .max(10)
+    .default(3)
+    .describe("Link-following depth (0 = start page + sitemap only)"),
+  include_patterns: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Glob patterns — only include URLs whose path matches at least one (e.g., ['/docs/*'])",
+    ),
+  exclude_patterns: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Glob patterns — exclude URLs whose path matches any (e.g., ['/tag/*', '/page/*'])",
+    ),
+  search: z
+    .string()
+    .max(500)
+    .optional()
+    .describe(
+      "Query to filter and rank discovered URLs by relevance (returns relevance_score per URL)",
+    ),
+  sitemap: z
+    .enum(["skip", "include", "only"])
+    .default("include")
+    .describe(
+      "Sitemap handling: include (parse sitemaps + follow links), skip (links only), only (sitemap URLs only)",
+    ),
+  include_metadata: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Fetch title and meta description for each URL via lightweight GET (adds latency)",
+    ),
+  include_subdomains: z
+    .boolean()
+    .default(false)
+    .describe("Include URLs from subdomains of the target domain"),
+  respect_robots: z
+    .boolean()
+    .default(true)
+    .describe("Respect robots.txt directives"),
+});
+
+export const mapDescription =
+  "Discover all URLs on a website via sitemap parsing and link extraction. " +
+  "No JS rendering, no content scraping — pure lightweight URL discovery. " +
+  "Costs $0.001 per call regardless of how many URLs are found. " +
+  "Returns a flat list of URLs with source (sitemap/link) and depth. " +
+  "Use include_patterns/exclude_patterns to scope discovery to specific sections. " +
+  "Use search to rank URLs by relevance to a query. " +
+  "Use include_metadata=true to also fetch page titles and descriptions.";
+
+export async function handleMap(
+  client: AlterLabClient,
+  params: z.infer<typeof mapSchema>,
+): Promise<CallToolResult> {
+  try {
+    const response = await client.map({
+      url: params.url,
+      max_pages: params.max_pages,
+      max_depth: params.max_depth,
+      include_patterns: params.include_patterns,
+      exclude_patterns: params.exclude_patterns,
+      search: params.search,
+      sitemap: params.sitemap,
+      include_metadata: params.include_metadata,
+      include_subdomains: params.include_subdomains,
+      respect_robots: params.respect_robots,
+    });
+
+    const text = formatMapResponse(response, params.url);
+    return { content: [{ type: "text", text }] };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error, { url: params.url });
+    }
+    return formatErrorResult(error as Error, { url: params.url });
+  }
+}
+
+function formatMapResponse(response: unknown, startUrl: string): string {
+  const r = response as Record<string, unknown>;
+  const mapId = String(r.map_id ?? "");
+  const totalUrls = Number(r.total_urls ?? 0);
+  const sitemapFound = Boolean(r.sitemap_found);
+  const creditsUsed = Number(r.credits_used ?? 0);
+  const urls = Array.isArray(r.urls) ? r.urls : [];
+
+  const parts: string[] = [
+    `**Site Map: ${startUrl}**\n`,
+    `- Map ID: \`${mapId}\``,
+    `- URLs discovered: ${totalUrls}`,
+    `- Sitemap found: ${sitemapFound ? "Yes" : "No"}`,
+    `- Credits used: ${creditsUsed}`,
+    "",
+  ];
+
+  // robots.txt info
+  const robotsTxt = r.robots_txt as Record<string, unknown> | undefined;
+  if (robotsTxt && robotsTxt.exists) {
+    const disallowed = Array.isArray(robotsTxt.disallowed_paths)
+      ? robotsTxt.disallowed_paths
+      : [];
+    if (disallowed.length > 0) {
+      parts.push(
+        `**robots.txt**: ${disallowed.length} disallowed path${disallowed.length !== 1 ? "s" : ""}`,
+      );
+    }
+  }
+
+  // Show up to 50 URLs
+  const preview = urls.slice(0, 50);
+  if (preview.length > 0) {
+    parts.push(
+      `\n**Discovered URLs** (showing ${preview.length} of ${totalUrls}):\n`,
+    );
+    for (const entry of preview) {
+      const e = entry as Record<string, unknown>;
+      const url = String(e.url ?? "");
+      const source = String(e.source ?? "");
+      const depth = Number(e.depth ?? 0);
+      const title = e.title ? ` — ${String(e.title)}` : "";
+      const score =
+        e.relevance_score !== null && e.relevance_score !== undefined
+          ? ` [relevance: ${Number(e.relevance_score).toFixed(2)}]`
+          : "";
+      parts.push(`- [${source}, depth ${depth}] ${url}${title}${score}`);
+    }
+    if (totalUrls > 50) {
+      parts.push(`\n... and ${totalUrls - 50} more URLs`);
+    }
+  } else {
+    parts.push("No URLs discovered.");
+  }
+
+  return parts.join("\n");
+}
+
+function isApiError(error: unknown): error is ApiError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof (error as ApiError).status === "number"
+  );
+}

--- a/src/tools/scrape.ts
+++ b/src/tools/scrape.ts
@@ -13,20 +13,26 @@ export const scrapeSchema = z.object({
       "Scraping mode: auto (recommended), html, js (headless browser), pdf, or ocr",
     ),
   formats: z
-    .array(z.enum(["text", "json", "html", "markdown"]))
+    .array(z.enum(["text", "json", "json_v2", "html", "markdown", "rag"]))
     .default(["markdown"])
-    .describe("Output formats. 'markdown' is best for LLM consumption"),
+    .describe(
+      "Output formats. 'markdown' is best for LLM consumption. " +
+        "'json_v2' returns a structured section tree (headings + content blocks). " +
+        "'rag' returns chunked text optimized for retrieval-augmented generation.",
+    ),
   render_js: z
-    .boolean()
+    .union([z.boolean(), z.literal("auto")])
     .default(false)
     .describe(
-      "Render JavaScript using headless browser (forces Tier 4 minimum — no separate add-on charge). Required for JS-heavy sites",
+      "Render JavaScript using headless browser (forces Tier 4 minimum — no separate add-on charge). " +
+        "Required for JS-heavy sites. Set to 'auto' for smart detection (probes each page, " +
+        "only renders JS-heavy pages with browser — saves 30-60% on mixed sites).",
     ),
   use_proxy: z
     .boolean()
     .default(false)
     .describe(
-      "Route through premium proxy (+1 credit). Helps bypass geo-restrictions and anti-bot",
+      "Route through premium proxy (+$0.0002). Helps bypass geo-restrictions and anti-bot",
     ),
   proxy_country: z
     .string()
@@ -67,15 +73,68 @@ export const scrapeSchema = z.object({
         '(e.g., {"session_token": "abc123"}). ' +
         "Use this for one-off requests; use session_id for reusable sessions.",
     ),
+  scroll_to_load: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Scroll page to trigger lazy-loaded content (requires render_js). " +
+        "Performs explicit viewport-height scrolls to load dynamic content. Adds ~2-3s latency.",
+    ),
+  scroll_count: z
+    .number()
+    .int()
+    .min(1)
+    .max(10)
+    .default(3)
+    .optional()
+    .describe(
+      "Number of scroll iterations when scroll_to_load is enabled (1-10, default 3)",
+    ),
+  remove_cookie_banners: z
+    .boolean()
+    .default(true)
+    .describe(
+      "Remove cookie consent banners from HTML before content extraction (free, enabled by default)",
+    ),
+  location: z
+    .object({
+      country: z
+        .string()
+        .length(2)
+        .optional()
+        .describe(
+          "ISO 3166-1 alpha-2 country code for geo-targeting (e.g., 'US', 'DE', 'JP'). " +
+            "Routes request through a proxy in the specified country.",
+        ),
+      language: z
+        .string()
+        .min(2)
+        .max(5)
+        .optional()
+        .describe(
+          "ISO 639-1 language code (e.g., 'en', 'de', 'ja'). " +
+            "Sets the Accept-Language header and browser locale.",
+        ),
+    })
+    .optional()
+    .describe(
+      "Geo-targeting parameters for localized content scraping. " +
+        "Controls proxy country routing, Accept-Language header, and browser locale.",
+    ),
 });
 
 export const scrapeDescription =
-  "Scrape a URL and return its content as markdown, text, HTML, or JSON. " +
+  "Scrape a URL and return its content as markdown, text, HTML, JSON, or structured sections. " +
   "Automatically handles anti-bot protection with tier escalation. " +
   "Returns markdown by default — optimized for LLM context. " +
   "Use render_js=true for JavaScript-heavy sites (React, Angular, SPAs). " +
+  "Use render_js='auto' for mixed sites to detect JS needs per-page (saves 30-60%). " +
   "Use use_proxy=true for geo-restricted or heavily protected sites. " +
-  "Supports authenticated scraping via session_id (stored session) or inline cookies.";
+  "Use formats=['json_v2'] for a structured section tree (headings + content blocks). " +
+  "Use formats=['rag'] for chunked text optimized for RAG pipelines. " +
+  "Supports authenticated scraping via session_id (stored session) or inline cookies. " +
+  "Use scroll_to_load=true for infinite-scroll pages that lazy-load content. " +
+  "Use location.country to scrape geo-targeted content.";
 
 export async function handleScrape(
   client: AlterLabClient,
@@ -92,11 +151,15 @@ export async function handleScrape(
       wait_for: params.wait_for,
       session_id: params.session_id,
       cookies: params.cookies,
+      location: params.location,
       advanced: {
         render_js: params.render_js,
         use_proxy: params.use_proxy,
         proxy_country: params.proxy_country,
         markdown: params.formats.includes("markdown"),
+        scroll_to_load: params.scroll_to_load,
+        scroll_count: params.scroll_count,
+        remove_cookie_banners: params.remove_cookie_banners,
       },
     });
 

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -23,7 +23,7 @@ export const screenshotDescription =
 
 export async function handleScreenshot(
   client: AlterLabClient,
-  params: z.infer<typeof screenshotSchema>
+  params: z.infer<typeof screenshotSchema>,
 ): Promise<CallToolResult> {
   try {
     // Screenshot requires render_js=true and screenshot=true
@@ -59,7 +59,7 @@ export async function handleScreenshot(
 
     // Fetch the screenshot image and return as base64
     const base64 = await client.fetchScreenshotAsBase64(
-      response.screenshot_url
+      response.screenshot_url,
     );
 
     const tier = response.billing.tier_used;

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1,0 +1,178 @@
+import { z } from "zod";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { AlterLabClient } from "../client.js";
+import { type ApiError, formatErrorResult } from "../errors.js";
+
+export const searchSchema = z.object({
+  query: z
+    .string()
+    .min(1)
+    .max(500)
+    .describe("Search query (max 500 characters)"),
+  num_results: z
+    .number()
+    .int()
+    .min(1)
+    .max(30)
+    .default(10)
+    .describe("Number of results to return (1-30)"),
+  page: z
+    .number()
+    .int()
+    .min(1)
+    .max(10)
+    .default(1)
+    .describe(
+      "Result page number (1-indexed). Page 2 returns results 11-20, etc.",
+    ),
+  domain: z
+    .string()
+    .optional()
+    .describe(
+      "Restrict results to a specific domain (applied as site: prefix, e.g. 'docs.example.com')",
+    ),
+  country: z
+    .string()
+    .length(2)
+    .optional()
+    .describe(
+      "ISO 3166-1 alpha-2 country code for geo-targeted results (e.g., 'US', 'GB', 'DE')",
+    ),
+  language: z
+    .string()
+    .min(2)
+    .max(5)
+    .optional()
+    .describe("Language code for results (e.g., 'en', 'fr', 'de')"),
+  time_range: z
+    .enum(["hour", "day", "week", "month", "year"])
+    .optional()
+    .describe("Filter results by recency"),
+  scrape_results: z
+    .boolean()
+    .default(false)
+    .describe(
+      "If true, scrape each result page and include content in response. " +
+        "Each page is billed at its scraping tier cost in addition to the base search fee.",
+    ),
+  formats: z
+    .array(z.enum(["text", "json", "json_v2", "html", "markdown"]))
+    .optional()
+    .describe("Output formats when scrape_results=true"),
+  extraction_schema: z
+    .record(z.unknown())
+    .optional()
+    .describe("JSON schema for structured extraction when scrape_results=true"),
+});
+
+export const searchDescription =
+  "Execute a web search and return SERP results (URLs, titles, snippets). " +
+  "Uses AlterLab's own SERP engine with Google/Bing/DuckDuckGo multi-engine failover. " +
+  "Costs $0.001 per search query. " +
+  "Set scrape_results=true to also scrape each result page and get full content — " +
+  "each page is billed at its normal scraping tier cost. " +
+  "Use domain to restrict results to a specific site (equivalent to site: operator). " +
+  "Use time_range to filter by recency (hour/day/week/month/year).";
+
+export async function handleSearch(
+  client: AlterLabClient,
+  params: z.infer<typeof searchSchema>,
+): Promise<CallToolResult> {
+  try {
+    const response = await client.search({
+      query: params.query,
+      num_results: params.num_results,
+      page: params.page,
+      domain: params.domain,
+      country: params.country,
+      language: params.language,
+      time_range: params.time_range,
+      scrape_results: params.scrape_results,
+      formats: params.formats,
+      extraction_schema: params.extraction_schema,
+    });
+
+    const text = formatSearchResponse(response, params.query);
+    return { content: [{ type: "text", text }] };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error, { url: params.query });
+    }
+    return formatErrorResult(error as Error, { url: params.query });
+  }
+}
+
+function formatSearchResponse(response: unknown, query: string): string {
+  const resp = response as Record<string, unknown>;
+  const searchId = String(resp.search_id ?? "");
+  const results = Array.isArray(resp.results) ? resp.results : [];
+  const resultsCount = Number(resp.results_count ?? results.length);
+  const creditsUsed = Number(resp.credits_used ?? 0);
+  const costBreakdown = resp.cost_breakdown as
+    | Record<string, unknown>
+    | undefined;
+
+  const parts: string[] = [
+    `**Search Results for: "${query}"**\n`,
+    `Found ${resultsCount} result${resultsCount !== 1 ? "s" : ""} | Search ID: \`${searchId}\`\n`,
+  ];
+
+  for (const result of results) {
+    const r = result as Record<string, unknown>;
+    const position = Number(r.position ?? 0);
+    const title = String(r.title ?? "Untitled");
+    const url = String(r.url ?? "");
+    const snippet = String(r.snippet ?? "");
+    const datePublished = r.date_published
+      ? ` (${String(r.date_published)})`
+      : "";
+
+    parts.push(`**${position}. ${title}**${datePublished}`);
+    parts.push(`${url}`);
+    parts.push(`${snippet}\n`);
+
+    // Include scraped content if available
+    const content = r.content as Record<string, unknown> | undefined;
+    if (content) {
+      const scrapeText =
+        (content.markdown as string | undefined) ||
+        (content.text as string | undefined);
+      if (scrapeText) {
+        const preview = scrapeText.slice(0, 500);
+        parts.push(`> ${preview}${scrapeText.length > 500 ? "..." : ""}\n`);
+      }
+    }
+  }
+
+  // Cost footer
+  parts.push("---");
+  if (costBreakdown) {
+    const total = Number(costBreakdown.total_microcents ?? 0);
+    parts.push(
+      `Cost: $${(total / 1_000_000).toFixed(6)} | Credits: ${creditsUsed}`,
+    );
+  } else {
+    parts.push(`Credits used: ${creditsUsed}`);
+  }
+
+  // Featured snippet, knowledge panel, PAA
+  const featuredSnippet = resp.featured_snippet as
+    | Record<string, unknown>
+    | undefined;
+  if (featuredSnippet) {
+    parts.unshift(
+      `**Featured Snippet**: ${String(featuredSnippet.content ?? "")}\n`,
+    );
+  }
+
+  return parts.join("\n");
+}
+
+function isApiError(error: unknown): error is ApiError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof (error as ApiError).status === "number"
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,13 +3,20 @@
 // ============================================================================
 
 export interface AdvancedOptions {
-  render_js?: boolean;
+  render_js?: boolean | "auto";
   screenshot?: boolean;
   markdown?: boolean;
   use_proxy?: boolean;
   proxy_country?: string;
   wait_condition?: string;
   remove_cookie_banners?: boolean;
+  scroll_to_load?: boolean;
+  scroll_count?: number;
+}
+
+export interface LocationOptions {
+  country?: string;
+  language?: string;
 }
 
 export interface UnifiedScrapeRequest {
@@ -17,7 +24,7 @@ export interface UnifiedScrapeRequest {
   mode?: "auto" | "html" | "js" | "pdf" | "ocr";
   sync?: boolean;
   advanced?: AdvancedOptions;
-  formats?: ("text" | "json" | "html" | "markdown")[];
+  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "rag")[];
   include_raw_html?: boolean;
   timeout?: number;
   extraction_schema?: Record<string, unknown>;
@@ -35,6 +42,186 @@ export interface UnifiedScrapeRequest {
   wait_until?: string;
   session_id?: string;
   cookies?: Record<string, string>;
+  location?: LocationOptions;
+}
+
+// ============================================================================
+// Crawl Types
+// ============================================================================
+
+export interface CrawlAdvancedOptions {
+  render_js?: boolean | "auto";
+  use_proxy?: boolean;
+  wait_for?: string;
+  timeout?: number;
+}
+
+export interface CrawlRequest {
+  url: string;
+  max_pages?: number;
+  max_depth?: number;
+  include_patterns?: string[];
+  exclude_patterns?: string[];
+  sitemap?: "include" | "skip" | "only";
+  sitemap_path?: string;
+  formats?: ("text" | "json" | "json_v2" | "html" | "markdown")[];
+  extraction_schema?: Record<string, unknown>;
+  max_concurrency?: number;
+  respect_robots?: boolean;
+  include_subdomains?: boolean;
+  webhook_url?: string;
+  advanced?: CrawlAdvancedOptions;
+}
+
+export interface CrawlResponse {
+  crawl_id: string;
+  status: string;
+  url: string;
+  created_at?: string;
+}
+
+export interface CrawlStatusResponse {
+  crawl_id: string;
+  status: string;
+  url: string;
+  pages_scraped?: number;
+  pages_total?: number;
+  credits_used?: number;
+  results?: Record<string, unknown>[];
+  error?: string;
+}
+
+export interface CrawlCancelResponse {
+  crawl_id: string;
+  status: string;
+  pages_scraped?: number;
+  credits_refunded?: number;
+}
+
+// ============================================================================
+// Search Types
+// ============================================================================
+
+export interface SearchRequest {
+  query: string;
+  num_results?: number;
+  page?: number;
+  domain?: string;
+  country?: string;
+  language?: string;
+  time_range?: "hour" | "day" | "week" | "month" | "year";
+  scrape_results?: boolean;
+  formats?: ("text" | "json" | "json_v2" | "html" | "markdown")[];
+  extraction_schema?: Record<string, unknown>;
+}
+
+export interface SearchResponse {
+  search_id: string;
+  query: string;
+  results_requested: number;
+  results_count: number;
+  credits_used: number;
+  results: Record<string, unknown>[];
+  cost_breakdown?: Record<string, unknown>;
+  featured_snippet?: Record<string, unknown>;
+  knowledge_panel?: Record<string, unknown>;
+  people_also_ask?: Record<string, unknown>[];
+}
+
+// ============================================================================
+// Map Types
+// ============================================================================
+
+export interface MapRequest {
+  url: string;
+  max_pages?: number;
+  max_depth?: number;
+  include_patterns?: string[];
+  exclude_patterns?: string[];
+  search?: string;
+  sitemap?: "skip" | "include" | "only";
+  sitemap_path?: string;
+  include_metadata?: boolean;
+  include_subdomains?: boolean;
+  respect_robots?: boolean;
+}
+
+export interface MapResponse {
+  map_id: string;
+  total_urls: number;
+  urls: Record<string, unknown>[];
+  sitemap_found: boolean;
+  robots_txt?: Record<string, unknown>;
+  credits_used: number;
+}
+
+// ============================================================================
+// Extract Types
+// ============================================================================
+
+export interface ExtractRequest {
+  content: string;
+  content_type?: "html" | "text" | "markdown";
+  extraction_schema?: Record<string, unknown>;
+  extraction_profile?:
+    | "auto"
+    | "product"
+    | "article"
+    | "job_posting"
+    | "faq"
+    | "recipe"
+    | "event";
+  extraction_prompt?: string;
+  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "rag")[];
+  source_url?: string;
+  evidence?: boolean;
+}
+
+export interface ExtractResponse {
+  extract_id: string;
+  formats: Record<string, unknown>;
+  credits_used: number;
+  model_used?: string;
+  extraction_method: string;
+  content_size_chars: number;
+}
+
+// ============================================================================
+// Batch Types
+// ============================================================================
+
+export interface BatchItemRequest {
+  url: string;
+  mode?: "auto" | "html" | "js" | "pdf" | "ocr";
+  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "rag")[];
+  extraction_schema?: Record<string, unknown>;
+  timeout?: number;
+  wait_for?: string;
+  cache?: boolean;
+  advanced?: AdvancedOptions;
+}
+
+export interface BatchRequest {
+  urls: BatchItemRequest[];
+  webhook_url?: string;
+}
+
+export interface BatchResponse {
+  batch_id: string;
+  status: string;
+  total_urls: number;
+  estimated_credits: number;
+  job_ids?: string[];
+}
+
+export interface BatchStatusResponse {
+  batch_id: string;
+  status: string;
+  total_urls: number;
+  completed?: number;
+  failed?: number;
+  credits_used?: number;
+  items?: Record<string, unknown>[];
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add `alterlab_crawl` (start async crawl), `alterlab_crawl_status` (poll results), `alterlab_crawl_cancel` (cancel + refund)
- Add `alterlab_search` (SERP search via Google/Bing/DDG with optional per-result scraping)
- Add `alterlab_map` (lightweight URL discovery via sitemap + link extraction, \$0.001/call)
- Add `alterlab_batch` (submit up to 100 URLs for parallel scraping) and `alterlab_batch_status`
- Fix `alterlab_extract`: was incorrectly calling `/v1/scrape` — now calls `/v1/extract` with the correct payload (raw content, not a URL to fetch)
- Add `json_v2` and `rag` to scrape and extract formats enum
- Add `render_js='auto'`, `scroll_to_load`, `scroll_count`, `remove_cookie_banners`, and `location` (country/language geo-targeting) to `alterlab_scrape`
- Expand `AdvancedOptions`, `UnifiedScrapeRequest`, and `types.ts` with all new API types
- Bump server version to 1.2.0

Resolves ecosystem sync gap — MCP server now has full API parity with the AlterLab v1 API.

## Test plan

- [ ] `alterlab_scrape` with `formats=['json_v2']` and `formats=['rag']`
- [ ] `alterlab_scrape` with `render_js='auto'` and `location.country='DE'`
- [ ] `alterlab_extract` passes raw HTML content to `/v1/extract` (not `/v1/scrape`)
- [ ] `alterlab_crawl` starts a crawl and returns `crawl_id`
- [ ] `alterlab_crawl_status` polls and returns page results when completed
- [ ] `alterlab_search` returns SERP results for a query
- [ ] `alterlab_map` returns discovered URLs for a domain
- [ ] `alterlab_batch` submits multiple URLs and returns `batch_id`
- [ ] `alterlab_batch_status` returns item-level results