### PR TITLE
Feat: add max_response_bytes scrape parameter (sync #137)

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -69,6 +69,16 @@ export function formatScrapeResponse(response: UnifiedScrapeResponse): string {
     parts.push(`Tip: ${response.billing.optimization_suggestion}`);
   }
 
+  if (response.content_truncated) {
+    const t = response.content_truncated;
+    const truncatedMB = (t.truncated_at_bytes / 1_048_576).toFixed(1);
+    const originalMB = (t.original_size_bytes / 1_048_576).toFixed(1);
+    parts.push(
+      `Warning: Content truncated at ${truncatedMB} MB (original: ${originalMB} MB, reason: ${t.truncation_reason}). ` +
+        `Increase max_response_bytes or use a more targeted selector to capture the full page.`,
+    );
+  }
+
   return parts.join("\n");
 }
 

--- a/src/tools/scrape.ts
+++ b/src/tools/scrape.ts
@@ -72,6 +72,19 @@ export const scrapeSchema = z.object({
     .max(300)
     .default(90)
     .describe("Request timeout in seconds (1-300)"),
+  max_response_bytes: z
+    .number()
+    .int()
+    .min(0)
+    .max(52_428_800)
+    .default(5_242_880)
+    .optional()
+    .describe(
+      "Soft cap on raw response body size in bytes. " +
+        "When the downloaded HTML exceeds this value it is truncated before extraction. " +
+        "Default: 5 MB (5242880). Set to 0 for no limit. Maximum: 50 MB (52428800). " +
+        "Useful for very large pages where you only need the beginning of the content.",
+    ),
   include_raw_html: z
     .boolean()
     .default(false)
@@ -172,6 +185,7 @@ export async function handleScrape(
       formats: params.formats,
       sync: true,
       timeout: params.timeout,
+      max_response_bytes: params.max_response_bytes,
       include_raw_html: params.include_raw_html,
       wait_for: params.wait_for,
       session_id: params.session_id,

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface UnifiedScrapeRequest {
   formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "rag")[];
   include_raw_html?: boolean;
   timeout?: number;
+  max_response_bytes?: number;
   extraction_schema?: Record<string, unknown>;
   extraction_prompt?: string;
   extraction_profile?:
@@ -308,6 +309,25 @@ export interface SessionRefreshRequest {
 // API Response Types
 // ============================================================================
 
+export interface ContentTruncationInfo {
+  /** Always true when this object is present. */
+  truncated: boolean;
+  /** Number of bytes at which the content was cut before processing. */
+  truncated_at_bytes: number;
+  /** Original content size in bytes before truncation. */
+  original_size_bytes: number;
+  /**
+   * Why truncation occurred:
+   * - 'readability_input_cap': HTML exceeded 2 MB before Readability processing
+   * - 'readability_output_cap': extracted text exceeded the output size cap
+   * - 'response_body_cap': raw response body exceeded max_response_bytes limit
+   */
+  truncation_reason:
+    | "readability_input_cap"
+    | "readability_output_cap"
+    | "response_body_cap";
+}
+
 export interface TierEscalationDetail {
   tier: string;
   result: "success" | "failed" | "skipped";
@@ -344,6 +364,7 @@ export interface UnifiedScrapeResponse {
   screenshot_url?: string;
   pdf_url?: string;
   filtered_content?: Record<string, unknown>;
+  content_truncated?: ContentTruncationInfo;
   billing: BillingDetails;
   extraction_method?: string;
   version?: string;


### PR DESCRIPTION
## Summary

Syncs MCP server with AlterLab API PR #12357 which introduced a soft cap on raw response body size before content extraction.

- Adds `max_response_bytes` (int, 0–52428800, default 5 MB) to the `alterlab_scrape` Zod schema
- Passes parameter through to the HTTP client
- Updates `UnifiedScrapeRequest` TypeScript type with `max_response_bytes?: number`
- Adds `ContentTruncationInfo` interface and `content_truncated` field to `UnifiedScrapeResponse`
- Surfaces a truncation warning in `formatScrapeResponse` output so LLM consumers know when content was cut

Closes #137

## Test Plan

- [x] `npm run build` passes — no TypeScript errors
- [x] Prettier formatting: all changed files unchanged
- [ ] Manual: pass `max_response_bytes=1000` to a large page and verify `content_truncated` warning appears in output