### PR TITLE
Feat: Add extraction_schema and content format to scrape tool

### DIFF
--- a/src/tools/scrape.ts
+++ b/src/tools/scrape.ts
@@ -33,12 +33,22 @@ export const scrapeSchema = z.object({
       "Scraping mode: auto (recommended), html, js (headless browser), pdf, or ocr",
     ),
   formats: z
-    .array(z.enum(["text", "json", "json_v2", "html", "markdown", "rag"]))
+    .array(z.enum(["text", "json", "json_v2", "html", "markdown", "rag", "content"]))
     .default(["markdown"])
     .describe(
       "Output formats. 'markdown' is best for LLM consumption. " +
         "'json_v2' returns a structured section tree (headings + content blocks). " +
-        "'rag' returns chunked text optimized for retrieval-augmented generation.",
+        "'rag' returns chunked text optimized for retrieval-augmented generation. " +
+        "'content' returns body_markdown + content_hash + images + links for AI/KB pipelines.",
+    ),
+  extraction_schema: z
+    .record(z.unknown())
+    .optional()
+    .describe(
+      "JSON schema for structured extraction. " +
+        "The API extracts fields matching this schema from the scraped page using LLM. " +
+        "Result is returned in extraction_result. " +
+        'Example: { "title": "string", "price": "number", "in_stock": "boolean" }',
     ),
   render_js: z
     .union([z.boolean(), z.literal("auto")])
@@ -168,6 +178,8 @@ export const scrapeDescription =
   "Use use_proxy=true for geo-restricted or heavily protected sites. " +
   "Use formats=['json_v2'] for a structured section tree (headings + content blocks). " +
   "Use formats=['rag'] for chunked text optimized for RAG pipelines. " +
+  "Use formats=['content'] for AI/KB pipelines — returns body_markdown, content_hash, images, links. " +
+  "Use extraction_schema to extract structured fields from the page using LLM (returned in extraction_result). " +
   "Supports authenticated scraping via session_id (stored session) or inline cookies. " +
   "Use scroll_to_load=true for infinite-scroll pages that lazy-load content. " +
   "Use location.country to scrape geo-targeted content.";
@@ -191,6 +203,7 @@ export async function handleScrape(
       session_id: params.session_id,
       cookies: params.cookies,
       location: params.location,
+      extraction_schema: params.extraction_schema,
       advanced: {
         render_js: params.render_js,
         use_proxy: params.use_proxy,

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export interface UnifiedScrapeRequest {
   mode?: "auto" | "html" | "js" | "pdf" | "ocr";
   sync?: boolean;
   advanced?: AdvancedOptions;
-  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "rag")[];
+  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "rag" | "content")[];
   include_raw_html?: boolean;
   timeout?: number;
   max_response_bytes?: number;
@@ -67,7 +67,7 @@ export interface CrawlRequest {
   exclude_patterns?: string[];
   sitemap?: "include" | "skip" | "only";
   sitemap_path?: string;
-  formats?: ("text" | "json" | "json_v2" | "html" | "markdown")[];
+  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "content")[];
   extraction_schema?: Record<string, unknown>;
   max_concurrency?: number;
   respect_robots?: boolean;
@@ -114,7 +114,7 @@ export interface SearchRequest {
   language?: string;
   time_range?: "hour" | "day" | "week" | "month" | "year";
   scrape_results?: boolean;
-  formats?: ("text" | "json" | "json_v2" | "html" | "markdown")[];
+  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "content")[];
   extraction_schema?: Record<string, unknown>;
 }
 
@@ -175,7 +175,7 @@ export interface ExtractRequest {
     | "recipe"
     | "event";
   extraction_prompt?: string;
-  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "rag")[];
+  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "rag" | "content")[];
   source_url?: string;
   evidence?: boolean;
 }
@@ -196,7 +196,7 @@ export interface ExtractResponse {
 export interface BatchItemRequest {
   url: string;
   mode?: "auto" | "html" | "js" | "pdf" | "ocr";
-  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "rag")[];
+  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "rag" | "content")[];
   extraction_schema?: Record<string, unknown>;
   timeout?: number;
   wait_for?: string;


### PR DESCRIPTION
## Summary

Part of AlterLab/AlterLab#4271 — SDK support for extraction_schema and content format.

### Changes
- Add `extraction_schema` Zod field to `scrapeSchema` (follows same pattern as `batch.ts` and `crawl.ts`)
- Wire `extraction_schema` into the `client.scrape()` API payload
- Add `"content"` to formats enum in `scrapeSchema`
- Update `scrapeDescription` to document both content format and extraction_schema
- Add `"content"` to all formats unions in `types.ts` (5 interfaces updated)

## Test plan
- [ ] `alterlab_scrape` MCP tool schema includes `extraction_schema` param
- [ ] `extraction_schema` forwarded in API payload when provided
- [ ] `"content"` available as a format option in the scrape tool