### PR TITLE
feat(sync): comprehensive API parity

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -48,6 +48,28 @@ export function formatScrapeResponse(response: UnifiedScrapeResponse): string {
     parts.push(content);
   }
 
+  // Extraction result (LLM-extracted fields from extraction_prompt)
+  if (response.extraction_result) {
+    parts.push(
+      "\n**Extraction Result**\n```json\n" +
+        JSON.stringify(response.extraction_result, null, 2) +
+        "\n```",
+    );
+  }
+
+  // Browser action results
+  if (response.action_results && response.action_results.length > 0) {
+    const actionSummary = response.action_results
+      .map((a: Record<string, unknown>, i: number) => {
+        const status = a.success ? "ok" : "failed";
+        const type = String(a.type ?? "action");
+        const result = a.result ? ` → ${String(a.result)}` : "";
+        return `  ${i + 1}. [${status}] ${type}${result}`;
+      })
+      .join("\n");
+    parts.push(`\n**Action Results**\n${actionSummary}`);
+  }
+
   // Metadata footer
   const tier = response.billing.tier_used;
   const tierName = TIER_NAMES[tier] || tier;
@@ -67,6 +89,33 @@ export function formatScrapeResponse(response: UnifiedScrapeResponse): string {
 
   if (response.billing.optimization_suggestion) {
     parts.push(`Tip: ${response.billing.optimization_suggestion}`);
+  }
+
+  // Warnings — surface all warning variants
+  if (response.warning) {
+    parts.push(`Warning: ${response.warning}`);
+  }
+
+  if (response.domain_warning) {
+    let detail = "";
+    if (response.domain_difficulty) {
+      const d = response.domain_difficulty as Record<string, unknown>;
+      const rate = d.success_rate !== undefined
+        ? ` (success rate: ${(Number(d.success_rate) * 100).toFixed(0)}%)`
+        : "";
+      detail = rate;
+    }
+    parts.push(`Domain Warning: ${response.domain_warning}${detail}`);
+  }
+
+  if (response.tier_cap_warning) {
+    const w = response.tier_cap_warning as Record<string, unknown>;
+    const domainMin = w.domain_min_tier !== undefined ? ` Domain requires tier ${w.domain_min_tier}.` : "";
+    if (w.your_max_tier !== undefined) {
+      parts.push(`Tier Cap Warning: Your max_tier (${w.your_max_tier}) is below the domain minimum.${domainMin}`);
+    } else if (w.your_force_tier !== undefined) {
+      parts.push(`Tier Cap Warning: Your force_tier (${w.your_force_tier}) is below the domain minimum.${domainMin}`);
+    }
   }
 
   if (response.content_truncated) {

--- a/src/tools/crawl.ts
+++ b/src/tools/crawl.ts
@@ -7,6 +7,29 @@ import { type ApiError, formatErrorResult } from "../errors.js";
 // Start Crawl
 // ============================================================================
 
+const crawlTierEnum = z.enum(["1", "2", "3", "3.5", "4"]);
+
+const crawlCostControlsSchema = z
+  .object({
+    max_credits: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Hard spending cap in credits for the entire crawl"),
+    max_tier: crawlTierEnum
+      .optional()
+      .describe(
+        "Maximum tier to use for page scrapes " +
+          "(1=curl $0.0002, 2=http $0.0003, 3=stealth $0.002, 3.5=lightjs $0.0025, 4=browser $0.004)",
+      ),
+    force_tier: crawlTierEnum
+      .optional()
+      .describe("Force all pages to use this exact tier, bypassing per-page escalation"),
+  })
+  .optional()
+  .describe("Cost controls for the entire crawl — cap total spend or pin the scraping tier");
+
 export const crawlSchema = z.object({
   url: z.string().url().describe("Start URL for the crawl"),
   max_pages: z
@@ -43,6 +66,13 @@ export const crawlSchema = z.object({
     .describe(
       "Sitemap mode: include (default), skip (link extraction only), only (sitemap URLs only)",
     ),
+  sitemap_path: z
+    .string()
+    .optional()
+    .describe(
+      "Explicit path to the sitemap file (e.g., '/sitemap_index.xml'). " +
+        "Use when the sitemap is not at the standard /sitemap.xml location.",
+    ),
   formats: z
     .array(z.enum(["text", "json", "json_v2", "html", "markdown"]))
     .optional()
@@ -51,6 +81,20 @@ export const crawlSchema = z.object({
     .record(z.unknown())
     .optional()
     .describe("JSON schema for structured extraction on each page"),
+  extraction_profile: z
+    .enum(["auto", "product", "article", "job_posting", "faq", "recipe", "event"])
+    .optional()
+    .describe(
+      "Pre-defined extraction profile applied to every crawled page. " +
+        "'auto' detects the page type automatically.",
+    ),
+  headers: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe(
+      "Custom HTTP headers injected into every page request during the crawl " +
+        '(e.g., {"Authorization": "Bearer token"}). Maximum 50 headers.',
+    ),
   render_js: z
     .union([z.boolean(), z.literal("auto")])
     .default(false)
@@ -76,11 +120,25 @@ export const crawlSchema = z.object({
     .boolean()
     .default(false)
     .describe("Include links to subdomains during discovery"),
+  wait_for: z
+    .string()
+    .optional()
+    .describe(
+      "CSS selector to wait for before extracting each page (e.g., '#main-content'). " +
+        "Applied to all pages in the crawl.",
+    ),
+  timeout: z
+    .number()
+    .min(1)
+    .max(300)
+    .optional()
+    .describe("Per-page request timeout in seconds (1-300)"),
   webhook_url: z
     .string()
     .url()
     .optional()
     .describe("Webhook URL to notify on crawl completion"),
+  cost_controls: crawlCostControlsSchema,
 });
 
 export const crawlDescription =
@@ -89,7 +147,9 @@ export const crawlDescription =
   "Returns a crawl_id immediately — use alterlab_crawl_status to poll results. " +
   "Use include_patterns/exclude_patterns to scope the crawl to specific sections. " +
   "Use render_js='auto' for mixed sites to save 30-60% vs always rendering. " +
-  "Supports extraction_schema to extract structured data from every page.";
+  "Supports extraction_schema or extraction_profile to extract structured data from every page. " +
+  "Use cost_controls to cap total credits or pin the scraping tier for all pages. " +
+  "Use sitemap_path to specify a non-standard sitemap location.";
 
 export async function handleCrawl(
   client: AlterLabClient,
@@ -103,15 +163,21 @@ export async function handleCrawl(
       include_patterns: params.include_patterns,
       exclude_patterns: params.exclude_patterns,
       sitemap: params.sitemap,
+      sitemap_path: params.sitemap_path,
       formats: params.formats,
       extraction_schema: params.extraction_schema,
+      extraction_profile: params.extraction_profile,
+      headers: params.headers,
       max_concurrency: params.max_concurrency,
       respect_robots: params.respect_robots,
       include_subdomains: params.include_subdomains,
       webhook_url: params.webhook_url,
+      cost_controls: params.cost_controls,
       advanced: {
         render_js: params.render_js,
         use_proxy: params.use_proxy,
+        wait_for: params.wait_for,
+        timeout: params.timeout,
       },
     });
 

--- a/src/tools/map.ts
+++ b/src/tools/map.ts
@@ -44,6 +44,13 @@ export const mapSchema = z.object({
     .describe(
       "Sitemap handling: include (parse sitemaps + follow links), skip (links only), only (sitemap URLs only)",
     ),
+  sitemap_path: z
+    .string()
+    .optional()
+    .describe(
+      "Explicit path to the sitemap file (e.g., '/sitemap_index.xml'). " +
+        "Use when the sitemap is not at the standard /sitemap.xml location.",
+    ),
   include_metadata: z
     .boolean()
     .default(false)
@@ -82,6 +89,7 @@ export async function handleMap(
       exclude_patterns: params.exclude_patterns,
       search: params.search,
       sitemap: params.sitemap,
+      sitemap_path: params.sitemap_path,
       include_metadata: params.include_metadata,
       include_subdomains: params.include_subdomains,
       respect_robots: params.respect_robots,

--- a/src/tools/scrape.ts
+++ b/src/tools/scrape.ts
@@ -4,27 +4,90 @@ import type { AlterLabClient } from "../client.js";
 import { type ApiError, formatErrorResult } from "../errors.js";
 import { formatScrapeResponse } from "../format.js";
 
+const tierEnum = z.enum(["1", "2", "3", "3.5", "4"]);
+
+const costControlsSchema = z
+  .object({
+    force_tier: tierEnum
+      .optional()
+      .describe(
+        "Pin execution to this exact tier, bypassing escalation " +
+          "(1=curl $0.0002, 2=http $0.0003, 3=stealth $0.002, 3.5=lightjs $0.0025, 4=browser $0.004). " +
+          "Use to guarantee a specific engine is used regardless of site difficulty.",
+      ),
+    max_tier: tierEnum
+      .optional()
+      .describe(
+        "Cap automatic escalation at this tier. Scrape will not escalate beyond it even if lower tiers fail. " +
+          "Cannot exceed force_tier when both are set.",
+      ),
+    max_credits: z
+      .number()
+      .positive()
+      .optional()
+      .describe("Hard spending cap for this request in credits. Request fails if cost would exceed this."),
+    prefer_cost: z
+      .boolean()
+      .optional()
+      .describe("Optimize for cost — try cheaper tiers first, accept lower success probability"),
+    prefer_speed: z
+      .boolean()
+      .optional()
+      .describe("Optimize for speed — skip to the most reliable tier for this domain"),
+    fail_fast: z
+      .boolean()
+      .optional()
+      .describe("Return error instead of escalating to more expensive tiers on failure"),
+    time_budget: z
+      .number()
+      .min(5)
+      .max(300)
+      .optional()
+      .describe(
+        "Total wall-clock budget in seconds for the entire tier escalation sequence (5–300s). " +
+          "Escalation stops when remaining budget is insufficient for the next tier attempt.",
+      ),
+  })
+  .optional()
+  .describe(
+    "Fine-grained cost and tier controls. Use to cap spending, pin a tier, or trade off cost vs speed.",
+  );
+
 export const scrapeSchema = z.object({
   url: z.string().url().describe("URL to scrape"),
   method: z
-    .enum(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"])
+    .enum(["GET", "POST"])
     .default("GET")
     .describe(
-      "HTTP method for the request. Default GET (standard page scraping). " +
-        "Use POST for GraphQL endpoints, form submissions, REST API calls. " +
-        "Use PUT/PATCH for REST API updates. " +
-        "When using POST/PUT/PATCH, provide body with the request payload.",
+      "HTTP method. Default GET (standard page scraping). " +
+        "Use POST for GraphQL endpoints, form submissions, and REST API calls. " +
+        "When using POST, provide body with the request payload. POST costs 1.5x base tier price.",
     ),
   body: z
     .string()
     .optional()
     .describe(
-      "Request body for POST/PUT/PATCH requests. " +
+      "Request body for POST requests. " +
         "For GraphQL: JSON string with 'query' and optional 'variables' fields " +
         '(e.g., \'{"query": "{ user { id name } }"}\').' +
         "For REST APIs: JSON-encoded payload string. " +
         "For form submissions: URL-encoded key=value pairs (e.g., 'name=Alice&email=alice@example.com'). " +
-        "Omit for GET/HEAD/DELETE requests.",
+        "Omit for GET requests.",
+    ),
+  content_type: z
+    .enum([
+      "application/json",
+      "application/x-www-form-urlencoded",
+      "text/plain",
+      "application/graphql",
+    ])
+    .optional()
+    .describe(
+      "Content-Type header for the request body. " +
+        "Defaults to 'application/json' when body is provided. " +
+        "Use 'application/graphql' for raw GraphQL queries. " +
+        "Use 'application/x-www-form-urlencoded' for HTML form submissions. " +
+        "Requires body to be set.",
     ),
   mode: z
     .enum(["auto", "html", "js", "pdf", "ocr"])
@@ -33,13 +96,12 @@ export const scrapeSchema = z.object({
       "Scraping mode: auto (recommended), html, js (headless browser), pdf, or ocr",
     ),
   formats: z
-    .array(z.enum(["text", "json", "json_v2", "html", "markdown", "rag", "content"]))
+    .array(z.enum(["text", "json", "json_v2", "html", "markdown", "rag"]))
     .default(["markdown"])
     .describe(
       "Output formats. 'markdown' is best for LLM consumption. " +
         "'json_v2' returns a structured section tree (headings + content blocks). " +
-        "'rag' returns chunked text optimized for retrieval-augmented generation. " +
-        "'content' returns body_markdown + content_hash + images + links for AI/KB pipelines.",
+        "'rag' returns chunked text optimized for retrieval-augmented generation.",
     ),
   extraction_schema: z
     .record(z.unknown())
@@ -49,6 +111,67 @@ export const scrapeSchema = z.object({
         "The API extracts fields matching this schema from the scraped page using LLM. " +
         "Result is returned in extraction_result. " +
         'Example: { "title": "string", "price": "number", "in_stock": "boolean" }',
+    ),
+  extraction_prompt: z
+    .string()
+    .max(2000)
+    .optional()
+    .describe(
+      "Natural language instruction for LLM extraction (max 2000 chars). " +
+        "Example: 'Extract the product name, price, availability, and all customer review scores.' " +
+        "Result is returned in the extraction_result field.",
+    ),
+  extraction_profile: z
+    .enum(["auto", "product", "article", "job_posting", "faq", "recipe", "event"])
+    .optional()
+    .describe(
+      "Pre-defined extraction profile used as schema template. " +
+        "'auto' detects the page type automatically. " +
+        "Applies optimized field extraction for the selected content type.",
+    ),
+  evidence: z
+    .boolean()
+    .optional()
+    .describe(
+      "Include provenance/evidence snippets alongside extracted fields. " +
+        "Each extracted value will include the source text passage it was derived from.",
+    ),
+  filter_content: z
+    .boolean()
+    .optional()
+    .describe(
+      "Apply quality filtering to extracted content. When false (default), returns all parsed content " +
+        "without quality thresholds (lossless mode). When true, filters low-quality boilerplate.",
+    ),
+  promote_schema_org: z
+    .boolean()
+    .optional()
+    .describe(
+      "Use Schema.org structured data as primary content source when available (default true). " +
+        "Set false to force extraction from raw HTML instead of embedded JSON-LD.",
+    ),
+  cache: z
+    .boolean()
+    .optional()
+    .describe(
+      "Enable caching for this request. When true, repeat requests with identical parameters may " +
+        "return cached results. Only use for idempotent requests (GET pages, read-only POSTs).",
+    ),
+  cache_ttl: z
+    .number()
+    .min(60)
+    .max(86400)
+    .optional()
+    .describe(
+      "Cache TTL in seconds (60–86400). Defaults to 3600 (60 min) when cache=true. " +
+        "Requires cache=true.",
+    ),
+  force_refresh: z
+    .boolean()
+    .optional()
+    .describe(
+      "Force a fresh fetch even when a cached result is available. " +
+        "Use to bypass cache for a single request without disabling caching globally.",
     ),
   render_js: z
     .union([z.boolean(), z.literal("auto")])
@@ -164,13 +287,14 @@ export const scrapeSchema = z.object({
       "Geo-targeting parameters for localized content scraping. " +
         "Controls proxy country routing, Accept-Language header, and browser locale.",
     ),
+  cost_controls: costControlsSchema,
 });
 
 export const scrapeDescription =
   "Scrape a URL and return its content as markdown, text, HTML, JSON, or structured sections. " +
   "Automatically handles anti-bot protection with tier escalation. " +
   "Returns markdown by default — optimized for LLM context. " +
-  "Supports GET (default) and POST/PUT/PATCH/DELETE/HEAD via the method parameter. " +
+  "Supports GET (default) and POST via the method parameter. " +
   "Use method='POST' with body for GraphQL APIs, REST endpoints, and form submissions. " +
   "For GraphQL: set body='{\"query\": \"{ ... }\"}' and method='POST'. " +
   "Use render_js=true for JavaScript-heavy sites (React, Angular, SPAs). " +
@@ -178,8 +302,11 @@ export const scrapeDescription =
   "Use use_proxy=true for geo-restricted or heavily protected sites. " +
   "Use formats=['json_v2'] for a structured section tree (headings + content blocks). " +
   "Use formats=['rag'] for chunked text optimized for RAG pipelines. " +
-  "Use formats=['content'] for AI/KB pipelines — returns body_markdown, content_hash, images, links. " +
   "Use extraction_schema to extract structured fields from the page using LLM (returned in extraction_result). " +
+  "Use extraction_prompt for natural-language extraction instructions. " +
+  "Use extraction_profile to apply pre-defined extraction templates (product, article, etc.). " +
+  "Use cost_controls to cap spending, pin a tier, or trade off cost vs speed. " +
+  "Use cache=true to enable caching for idempotent requests. " +
   "Supports authenticated scraping via session_id (stored session) or inline cookies. " +
   "Use scroll_to_load=true for infinite-scroll pages that lazy-load content. " +
   "Use location.country to scrape geo-targeted content.";
@@ -193,6 +320,7 @@ export async function handleScrape(
       url: params.url,
       method: params.method,
       body: params.body,
+      content_type: params.content_type,
       mode: params.mode,
       formats: params.formats,
       sync: true,
@@ -204,6 +332,15 @@ export async function handleScrape(
       cookies: params.cookies,
       location: params.location,
       extraction_schema: params.extraction_schema,
+      extraction_prompt: params.extraction_prompt,
+      extraction_profile: params.extraction_profile,
+      evidence: params.evidence,
+      filter_content: params.filter_content,
+      promote_schema_org: params.promote_schema_org,
+      cache: params.cache,
+      cache_ttl: params.cache_ttl,
+      force_refresh: params.force_refresh,
+      cost_controls: params.cost_controls,
       advanced: {
         render_js: params.render_js,
         use_proxy: params.use_proxy,

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -63,6 +63,13 @@ export const searchSchema = z.object({
     .record(z.unknown())
     .optional()
     .describe("JSON schema for structured extraction when scrape_results=true"),
+  safe_search: z
+    .boolean()
+    .optional()
+    .describe(
+      "Enable safe search filtering to exclude adult content from results. " +
+        "Defaults to the search engine's own safe-search setting when omitted.",
+    ),
 });
 
 export const searchDescription =
@@ -90,6 +97,7 @@ export async function handleSearch(
       scrape_results: params.scrape_results,
       formats: params.formats,
       extraction_schema: params.extraction_schema,
+      safe_search: params.safe_search,
     });
 
     const text = formatSearchResponse(response, params.query);

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,14 +19,35 @@ export interface LocationOptions {
   language?: string;
 }
 
+export interface CostControls {
+  force_tier?: "1" | "2" | "3" | "3.5" | "4";
+  max_tier?: "1" | "2" | "3" | "3.5" | "4";
+  max_credits?: number;
+  prefer_cost?: boolean;
+  prefer_speed?: boolean;
+  fail_fast?: boolean;
+  time_budget?: number;
+}
+
+export interface CrawlCostControls {
+  max_credits?: number;
+  max_tier?: "1" | "2" | "3" | "3.5" | "4";
+  force_tier?: "1" | "2" | "3" | "3.5" | "4";
+}
+
 export interface UnifiedScrapeRequest {
   url: string;
-  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD";
+  method?: "GET" | "POST";
   body?: string;
+  content_type?:
+    | "application/json"
+    | "application/x-www-form-urlencoded"
+    | "text/plain"
+    | "application/graphql";
   mode?: "auto" | "html" | "js" | "pdf" | "ocr";
   sync?: boolean;
   advanced?: AdvancedOptions;
-  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "rag" | "content")[];
+  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "rag")[];
   include_raw_html?: boolean;
   timeout?: number;
   max_response_bytes?: number;
@@ -40,6 +61,13 @@ export interface UnifiedScrapeRequest {
     | "faq"
     | "recipe"
     | "event";
+  evidence?: boolean;
+  filter_content?: boolean;
+  promote_schema_org?: boolean;
+  cache?: boolean;
+  cache_ttl?: number;
+  force_refresh?: boolean;
+  cost_controls?: CostControls;
   wait_for?: string;
   screenshot?: boolean;
   wait_until?: string;
@@ -67,12 +95,22 @@ export interface CrawlRequest {
   exclude_patterns?: string[];
   sitemap?: "include" | "skip" | "only";
   sitemap_path?: string;
-  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "content")[];
+  formats?: ("text" | "json" | "json_v2" | "html" | "markdown")[];
   extraction_schema?: Record<string, unknown>;
+  extraction_profile?:
+    | "auto"
+    | "product"
+    | "article"
+    | "job_posting"
+    | "faq"
+    | "recipe"
+    | "event";
+  headers?: Record<string, string>;
   max_concurrency?: number;
   respect_robots?: boolean;
   include_subdomains?: boolean;
   webhook_url?: string;
+  cost_controls?: CrawlCostControls;
   advanced?: CrawlAdvancedOptions;
 }
 
@@ -114,8 +152,9 @@ export interface SearchRequest {
   language?: string;
   time_range?: "hour" | "day" | "week" | "month" | "year";
   scrape_results?: boolean;
-  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "content")[];
+  formats?: ("text" | "json" | "json_v2" | "html" | "markdown")[];
   extraction_schema?: Record<string, unknown>;
+  safe_search?: boolean;
 }
 
 export interface SearchResponse {
@@ -364,7 +403,13 @@ export interface UnifiedScrapeResponse {
   screenshot_url?: string;
   pdf_url?: string;
   filtered_content?: Record<string, unknown>;
+  extraction_result?: Record<string, unknown>;
   content_truncated?: ContentTruncationInfo;
+  warning?: string;
+  domain_warning?: string;
+  domain_difficulty?: Record<string, unknown>;
+  tier_cap_warning?: Record<string, unknown>;
+  action_results?: Record<string, unknown>[];
   billing: BillingDetails;
   extraction_method?: string;
   version?: string;


### PR DESCRIPTION
Closes #213

Adds all missing parameters and response fields to bring the MCP server into full parity with the AlterLab API.

## Changes

### scrape tool
- **cost_controls** object: `force_tier`, `max_tier`, `max_credits`, `prefer_cost`, `prefer_speed`, `fail_fast`, `time_budget`
- **content_type** enum for POST body typing (`application/json`, `application/x-www-form-urlencoded`, `text/plain`, `application/graphql`)
- **extraction_prompt** (max 2000 chars) for natural-language LLM extraction
- **extraction_profile** enum (`auto`/`product`/`article`/`job_posting`/`faq`/`recipe`/`event`)
- **evidence**, **filter_content**, **promote_schema_org** boolean params
- **cache**, **cache_ttl** (60–86400s), **force_refresh** for caching control
- Fix method enum to GET/POST only — API does not accept PUT/PATCH/DELETE/HEAD
- Remove stale content format (does not exist in API); keep rag, remove raw (not useful for MCP context)

### crawl tool
- **cost_controls** object: max_credits, max_tier, force_tier
- **headers** for per-crawl custom HTTP headers
- **extraction_profile** enum applied to all crawled pages
- **sitemap_path** for non-standard sitemap locations
- **wait_for** and **timeout** forwarded into advanced

### search tool
- **safe_search** boolean param

### map tool
- **sitemap_path** string param

### format.ts
- Surface extraction_result as a JSON code block
- Surface action_results as a summary list
- Surface warning, domain_warning (with success rate), tier_cap_warning (with min tier)

### types.ts
- Add CostControls and CrawlCostControls interfaces
- Update all request/response types to match