### PR TITLE
Feat: Add extraction_model parameter to scrape, extract, and crawl tools

### DIFF
--- a/src/tools/crawl.ts
+++ b/src/tools/crawl.ts
@@ -51,6 +51,13 @@ export const crawlSchema = z.object({
     .record(z.unknown())
     .optional()
     .describe("JSON schema for structured extraction on each page"),
+  extraction_model: z
+    .string()
+    .nullish()
+    .describe(
+      "Per-request LLM model override in provider-specific format (e.g. 'gpt-4o', 'claude-opus-4-5-20251101', 'llama3-70b-8192'). " +
+        "Overrides the model saved in your BYOK key settings for this request only.",
+    ),
   render_js: z
     .union([z.boolean(), z.literal("auto")])
     .default(false)
@@ -105,6 +112,7 @@ export async function handleCrawl(
       sitemap: params.sitemap,
       formats: params.formats,
       extraction_schema: params.extraction_schema,
+      extraction_model: params.extraction_model ?? undefined,
       max_concurrency: params.max_concurrency,
       respect_robots: params.respect_robots,
       include_subdomains: params.include_subdomains,

--- a/src/tools/extract.ts
+++ b/src/tools/extract.ts
@@ -45,6 +45,13 @@ export const extractSchema = z.object({
       "Natural language instructions for LLM extraction (e.g., 'Extract all product prices and ratings'). " +
         "Charged at LLM extraction rate when provided.",
     ),
+  extraction_model: z
+    .string()
+    .nullish()
+    .describe(
+      "Per-request LLM model override in provider-specific format (e.g. 'gpt-4o', 'claude-opus-4-5-20251101', 'llama3-70b-8192'). " +
+        "Overrides the model saved in your BYOK key settings for this request only.",
+    ),
   formats: z
     .array(z.enum(["text", "json", "json_v2", "html", "markdown", "rag"]))
     .default(["json"])
@@ -87,6 +94,7 @@ export async function handleExtract(
       extraction_profile: params.extraction_profile,
       extraction_schema: params.extraction_schema,
       extraction_prompt: params.extraction_prompt,
+      extraction_model: params.extraction_model ?? undefined,
       formats: params.formats,
       source_url: params.source_url,
       evidence: params.evidence,

--- a/src/tools/scrape.ts
+++ b/src/tools/scrape.ts
@@ -33,7 +33,9 @@ export const scrapeSchema = z.object({
       "Scraping mode: auto (recommended), html, js (headless browser), pdf, or ocr",
     ),
   formats: z
-    .array(z.enum(["text", "json", "json_v2", "html", "markdown", "rag", "content"]))
+    .array(
+      z.enum(["text", "json", "json_v2", "html", "markdown", "rag", "content"]),
+    )
     .default(["markdown"])
     .describe(
       "Output formats. 'markdown' is best for LLM consumption. " +
@@ -49,6 +51,13 @@ export const scrapeSchema = z.object({
         "The API extracts fields matching this schema from the scraped page using LLM. " +
         "Result is returned in extraction_result. " +
         'Example: { "title": "string", "price": "number", "in_stock": "boolean" }',
+    ),
+  extraction_model: z
+    .string()
+    .nullish()
+    .describe(
+      "Per-request LLM model override in provider-specific format (e.g. 'gpt-4o', 'claude-opus-4-5-20251101', 'llama3-70b-8192'). " +
+        "Overrides the model saved in your BYOK key settings for this request only.",
     ),
   render_js: z
     .union([z.boolean(), z.literal("auto")])
@@ -204,6 +213,7 @@ export async function handleScrape(
       cookies: params.cookies,
       location: params.location,
       extraction_schema: params.extraction_schema,
+      extraction_model: params.extraction_model ?? undefined,
       advanced: {
         render_js: params.render_js,
         use_proxy: params.use_proxy,

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,12 +26,21 @@ export interface UnifiedScrapeRequest {
   mode?: "auto" | "html" | "js" | "pdf" | "ocr";
   sync?: boolean;
   advanced?: AdvancedOptions;
-  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "rag" | "content")[];
+  formats?: (
+    | "text"
+    | "json"
+    | "json_v2"
+    | "html"
+    | "markdown"
+    | "rag"
+    | "content"
+  )[];
   include_raw_html?: boolean;
   timeout?: number;
   max_response_bytes?: number;
   extraction_schema?: Record<string, unknown>;
   extraction_prompt?: string;
+  extraction_model?: string;
   extraction_profile?:
     | "auto"
     | "product"
@@ -69,6 +78,7 @@ export interface CrawlRequest {
   sitemap_path?: string;
   formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "content")[];
   extraction_schema?: Record<string, unknown>;
+  extraction_model?: string;
   max_concurrency?: number;
   respect_robots?: boolean;
   include_subdomains?: boolean;
@@ -175,7 +185,16 @@ export interface ExtractRequest {
     | "recipe"
     | "event";
   extraction_prompt?: string;
-  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "rag" | "content")[];
+  extraction_model?: string;
+  formats?: (
+    | "text"
+    | "json"
+    | "json_v2"
+    | "html"
+    | "markdown"
+    | "rag"
+    | "content"
+  )[];
   source_url?: string;
   evidence?: boolean;
 }
@@ -196,7 +215,15 @@ export interface ExtractResponse {
 export interface BatchItemRequest {
   url: string;
   mode?: "auto" | "html" | "js" | "pdf" | "ocr";
-  formats?: ("text" | "json" | "json_v2" | "html" | "markdown" | "rag" | "content")[];
+  formats?: (
+    | "text"
+    | "json"
+    | "json_v2"
+    | "html"
+    | "markdown"
+    | "rag"
+    | "content"
+  )[];
   extraction_schema?: Record<string, unknown>;
   timeout?: number;
   wait_for?: string;


### PR DESCRIPTION
## Summary
Syncs the MCP server with Node SDK PR #19988. Adds `extraction_model` as an optional nullable string parameter to the `scrape`, `extract`, and `crawl` tools, enabling per-request LLM model overrides for extraction.

## Changes
- `src/types.ts` — added `extraction_model?: string` to `UnifiedScrapeRequest`, `ExtractRequest`, and `CrawlRequest` interfaces
- `src/tools/scrape.ts` — added `extraction_model` to `scrapeSchema` with description; passes through to `client.scrape()`
- `src/tools/extract.ts` — added `extraction_model` to `extractSchema` with description; passes through to `client.extract()`
- `src/tools/crawl.ts` — added `extraction_model` to `crawlSchema` with description; passes through to `client.startCrawl()`

## Testing
- [ ] Call `alterlab_scrape` with `extraction_model='gpt-4o'` and verify it's sent in the API payload
- [ ] Call `alterlab_extract` with `extraction_model='claude-opus-4-5-20251101'` and verify passthrough
- [ ] Call `alterlab_crawl` with `extraction_model='llama3-70b-8192'` and verify passthrough
- [ ] Omit `extraction_model` — confirm it's absent from the API payload (no regression)

---
Closes #232
**Implementation branch**: `feat/extraction-model-232`
**Base**: `main`