### PR TITLE
Fix: add formats parameter to estimate tool (json_v2, rag, raw)

### DIFF
--- a/src/tools/estimate.ts
+++ b/src/tools/estimate.ts
@@ -10,6 +10,27 @@ export const estimateSchema = z.object({
     .enum(["auto", "html", "js", "pdf", "ocr"])
     .default("auto")
     .describe("Scraping mode"),
+  formats: z
+    .array(
+      z.enum([
+        "text",
+        "json",
+        "json_v2",
+        "html",
+        "markdown",
+        "rag",
+        "content",
+        "raw",
+      ]),
+    )
+    .optional()
+    .describe(
+      "Output formats to include in the estimate. Affects cost prediction accuracy. " +
+        "'json_v2' returns a structured section tree. " +
+        "'rag' returns chunked text for retrieval-augmented generation. " +
+        "'content' returns body_markdown + content_hash + images + links. " +
+        "'raw' returns the response body byte-for-byte with no transformation.",
+    ),
   render_js: z
     .boolean()
     .default(false)
@@ -35,6 +56,7 @@ export async function handleEstimate(
     const estimate = await client.estimate({
       url: params.url,
       mode: params.mode,
+      formats: params.formats,
       advanced: {
         render_js: params.render_js,
         use_proxy: params.use_proxy,

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface UnifiedScrapeRequest {
     | "markdown"
     | "rag"
     | "content"
+    | "raw"
   )[];
   include_raw_html?: boolean;
   timeout?: number;


### PR DESCRIPTION
## Summary

Adds the missing `formats` parameter to the `estimate` MCP tool, keeping it in parity with the AlterLab API after PR #19982 expanded the `CostEstimateRequest` formats enum.

## Changes

- `src/tools/estimate.ts`: Added optional `formats` array parameter to `estimateSchema` (full enum: `text`, `json`, `json_v2`, `html`, `markdown`, `rag`, `content`, `raw`). Passed through to `client.estimate()` call.
- `src/types.ts`: Added `raw` to `UnifiedScrapeRequest.formats` union type for API type parity.

## Testing

- [ ] Call estimate tool with `formats: ["json_v2"]` — no error
- [ ] Call estimate tool with `formats: ["raw"]` — no error
- [ ] Call estimate tool without `formats` — behaves as before (backwards compatible)
- [x] `npm run build` passes

---
Closes #234
**Implementation branch**: `fix/estimate-formats-234`
**Base**: `main`