### PR TITLE
Feat: Add beta feature management tools — list, enable, disable

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -5,6 +5,9 @@ import {
   type BatchRequest,
   type BatchResponse,
   type BatchStatusResponse,
+  type BetaFeatureListResponse,
+  type BetaFeatureMyResponse,
+  type BetaFeatureToggleResponse,
   type CostEstimate,
   type CrawlCancelResponse,
   type CrawlRequest,
@@ -224,6 +227,38 @@ export class AlterLabClient {
 
   async getBatchStatus(batchId: string): Promise<BatchStatusResponse> {
     return this.request<BatchStatusResponse>("GET", `/api/v1/batch/${batchId}`);
+  }
+
+  // ============================================================================
+  // Beta features methods
+  // ============================================================================
+
+  async listBetaFeatures(): Promise<BetaFeatureListResponse> {
+    return this.request<BetaFeatureListResponse>(
+      "GET",
+      "/api/v1/beta-features",
+    );
+  }
+
+  async listMyBetaFeatures(): Promise<BetaFeatureMyResponse> {
+    return this.request<BetaFeatureMyResponse>(
+      "GET",
+      "/api/v1/beta-features/my",
+    );
+  }
+
+  async enableBetaFeature(slug: string): Promise<BetaFeatureToggleResponse> {
+    return this.request<BetaFeatureToggleResponse>(
+      "POST",
+      `/api/v1/beta-features/${slug}/enable`,
+    );
+  }
+
+  async disableBetaFeature(slug: string): Promise<BetaFeatureToggleResponse> {
+    return this.request<BetaFeatureToggleResponse>(
+      "POST",
+      `/api/v1/beta-features/${slug}/disable`,
+    );
   }
 
   // ============================================================================

--- a/src/format.ts
+++ b/src/format.ts
@@ -2,6 +2,9 @@ import {
   TIER_NAMES,
   TIER_PRICES,
   type BalanceResponse,
+  type BetaFeatureListResponse,
+  type BetaFeatureMyResponse,
+  type BetaFeatureToggleResponse,
   type CostEstimate,
   type SessionCreateResponse,
   type SessionDetailResponse,
@@ -333,5 +336,82 @@ export function formatSessionRefreshResponse(
     `- Cookies: ${response.cookie_names.length}\n\n` +
     `Cookies have been rotated and failure counters reset. ` +
     `The session is ready for authenticated scraping.`
+  );
+}
+
+/**
+ * Format a beta features list response (all public features with opt-in state).
+ */
+export function formatBetaFeaturesListResponse(
+  response: BetaFeatureListResponse,
+): string {
+  if (response.features.length === 0) {
+    return (
+      "**No beta features available.**\n\n" +
+      "AlterLab has no public beta features at this time. " +
+      "Check back later for new capabilities in early access."
+    );
+  }
+
+  const parts: string[] = [`**Beta Features** (${response.total} total)\n`];
+
+  for (const feature of response.features) {
+    const statusLabel =
+      feature.status === "ga"
+        ? "GA"
+        : feature.status === "beta"
+          ? "Beta"
+          : "Hidden";
+    const optInLabel = feature.enabled ? "Opted in" : "Not opted in";
+
+    parts.push(
+      `- **${feature.name}** (\`${feature.slug}\`) [${statusLabel}]\n` +
+        `  ${feature.description}\n` +
+        `  Status: ${optInLabel}`,
+    );
+  }
+
+  parts.push(
+    "\nUse `alterlab_enable_beta_feature` or `alterlab_disable_beta_feature` to manage your opt-ins.",
+  );
+
+  return parts.join("\n");
+}
+
+/**
+ * Format a compact beta features list for the authenticated user (slugs only).
+ */
+export function formatBetaFeaturesMyResponse(
+  response: BetaFeatureMyResponse,
+): string {
+  if (response.features.length === 0) {
+    return (
+      "**Your Active Beta Features**: none\n\n" +
+      "You have no beta features enabled. " +
+      "Use `alterlab_list_beta_features` to see available features."
+    );
+  }
+
+  const slugList = response.features.map((slug) => `- \`${slug}\``).join("\n");
+
+  return (
+    `**Your Active Beta Features** (${response.features.length})\n\n` +
+    `${slugList}\n\n` +
+    `These features are active on your account (GA features + opted-in beta features).`
+  );
+}
+
+/**
+ * Format a beta feature enable/disable toggle response.
+ */
+export function formatBetaFeatureToggleResponse(
+  response: BetaFeatureToggleResponse,
+): string {
+  const action = response.enabled ? "Enabled" : "Disabled";
+  return (
+    `**Beta Feature ${action}**\n\n` +
+    `- Feature: \`${response.feature_slug}\`\n` +
+    `- Status: ${response.enabled ? "Active" : "Inactive"}\n\n` +
+    `${response.message}`
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,20 @@ import {
   deleteSessionDescription,
   handleDeleteSession,
 } from "./tools/sessions.js";
+import {
+  listBetaFeaturesSchema,
+  listBetaFeaturesDescription,
+  handleListBetaFeatures,
+  listMyBetaFeaturesSchema,
+  listMyBetaFeaturesDescription,
+  handleListMyBetaFeatures,
+  enableBetaFeatureSchema,
+  enableBetaFeatureDescription,
+  handleEnableBetaFeature,
+  disableBetaFeatureSchema,
+  disableBetaFeatureDescription,
+  handleDisableBetaFeature,
+} from "./tools/beta_features.js";
 
 function createServer(config: Config): McpServer {
   const client = new AlterLabClient(config);
@@ -214,6 +228,35 @@ function createServer(config: Config): McpServer {
     deleteSessionDescription,
     deleteSessionSchema.shape,
     (params) => handleDeleteSession(client, params as any),
+  );
+
+  // Beta feature management tools
+  server.tool(
+    "alterlab_list_beta_features",
+    listBetaFeaturesDescription,
+    listBetaFeaturesSchema.shape,
+    () => handleListBetaFeatures(client),
+  );
+
+  server.tool(
+    "alterlab_list_my_beta_features",
+    listMyBetaFeaturesDescription,
+    listMyBetaFeaturesSchema.shape,
+    () => handleListMyBetaFeatures(client),
+  );
+
+  server.tool(
+    "alterlab_enable_beta_feature",
+    enableBetaFeatureDescription,
+    enableBetaFeatureSchema.shape,
+    (params) => handleEnableBetaFeature(client, params as any),
+  );
+
+  server.tool(
+    "alterlab_disable_beta_feature",
+    disableBetaFeatureDescription,
+    disableBetaFeatureSchema.shape,
+    (params) => handleDisableBetaFeature(client, params as any),
   );
 
   return server;

--- a/src/tools/beta_features.ts
+++ b/src/tools/beta_features.ts
@@ -1,0 +1,159 @@
+import { z } from "zod";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { AlterLabClient } from "../client.js";
+import { type ApiError, formatErrorResult } from "../errors.js";
+import {
+  formatBetaFeaturesListResponse,
+  formatBetaFeaturesMyResponse,
+  formatBetaFeatureToggleResponse,
+} from "../format.js";
+
+// ============================================================================
+// List Beta Features
+// ============================================================================
+
+export const listBetaFeaturesSchema = z.object({});
+
+export const listBetaFeaturesDescription =
+  "List all public beta and GA features available on AlterLab, with your " +
+  "current opt-in state for each. Beta features require opting in; GA features " +
+  "are available to all users. Use alterlab_enable_beta_feature to opt in to " +
+  "any beta feature that interests you.";
+
+export async function handleListBetaFeatures(
+  client: AlterLabClient,
+): Promise<CallToolResult> {
+  try {
+    const response = await client.listBetaFeatures();
+    return {
+      content: [
+        { type: "text", text: formatBetaFeaturesListResponse(response) },
+      ],
+    };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error);
+    }
+    return formatErrorResult(error as Error);
+  }
+}
+
+// ============================================================================
+// List My Beta Features
+// ============================================================================
+
+export const listMyBetaFeaturesSchema = z.object({});
+
+export const listMyBetaFeaturesDescription =
+  "List all beta and GA features currently active on your account — a compact " +
+  "slug list for quick checks. Includes all GA features plus any beta features " +
+  "you have opted in to. Use this to verify which features are available before " +
+  "making API calls that require them.";
+
+export async function handleListMyBetaFeatures(
+  client: AlterLabClient,
+): Promise<CallToolResult> {
+  try {
+    const response = await client.listMyBetaFeatures();
+    return {
+      content: [{ type: "text", text: formatBetaFeaturesMyResponse(response) }],
+    };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error);
+    }
+    return formatErrorResult(error as Error);
+  }
+}
+
+// ============================================================================
+// Enable Beta Feature
+// ============================================================================
+
+export const enableBetaFeatureSchema = z.object({
+  slug: z
+    .string()
+    .min(1)
+    .describe(
+      "URL-safe slug of the beta feature to opt in to " +
+        "(e.g., 'v2-extraction', 'stealth-v3'). " +
+        "Use alterlab_list_beta_features to see available slugs.",
+    ),
+});
+
+export const enableBetaFeatureDescription =
+  "Opt in to a beta feature on your AlterLab account. " +
+  "Beta features are experimental capabilities available before general release. " +
+  "This operation is idempotent — calling it when already opted in returns success. " +
+  "Use alterlab_list_beta_features to discover available feature slugs.";
+
+export async function handleEnableBetaFeature(
+  client: AlterLabClient,
+  params: z.infer<typeof enableBetaFeatureSchema>,
+): Promise<CallToolResult> {
+  try {
+    const response = await client.enableBetaFeature(params.slug);
+    return {
+      content: [
+        { type: "text", text: formatBetaFeatureToggleResponse(response) },
+      ],
+    };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error);
+    }
+    return formatErrorResult(error as Error);
+  }
+}
+
+// ============================================================================
+// Disable Beta Feature
+// ============================================================================
+
+export const disableBetaFeatureSchema = z.object({
+  slug: z
+    .string()
+    .min(1)
+    .describe(
+      "URL-safe slug of the beta feature to opt out of " +
+        "(e.g., 'v2-extraction', 'stealth-v3'). " +
+        "Use alterlab_list_my_beta_features to see your currently active slugs.",
+    ),
+});
+
+export const disableBetaFeatureDescription =
+  "Opt out of a beta feature on your AlterLab account. " +
+  "This operation is idempotent — calling it when not opted in returns success. " +
+  "GA (generally available) features cannot be disabled.";
+
+export async function handleDisableBetaFeature(
+  client: AlterLabClient,
+  params: z.infer<typeof disableBetaFeatureSchema>,
+): Promise<CallToolResult> {
+  try {
+    const response = await client.disableBetaFeature(params.slug);
+    return {
+      content: [
+        { type: "text", text: formatBetaFeatureToggleResponse(response) },
+      ],
+    };
+  } catch (error) {
+    if (isApiError(error)) {
+      return formatErrorResult(error);
+    }
+    return formatErrorResult(error as Error);
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function isApiError(error: unknown): error is ApiError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof (error as ApiError).status === "number"
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -415,6 +415,38 @@ export interface BalanceResponse {
 }
 
 // ============================================================================
+// Beta Features Types
+// ============================================================================
+
+export type BetaFeatureStatus = "hidden" | "beta" | "ga";
+
+export interface BetaFeatureListItem {
+  slug: string;
+  name: string;
+  description: string;
+  status: BetaFeatureStatus;
+  created_at: string;
+  /** True if the current user has opted in to this feature. */
+  enabled: boolean;
+}
+
+export interface BetaFeatureListResponse {
+  features: BetaFeatureListItem[];
+  total: number;
+}
+
+export interface BetaFeatureMyResponse {
+  /** Sorted list of feature slugs accessible to the requesting user (GA + opted-in beta). */
+  features: string[];
+}
+
+export interface BetaFeatureToggleResponse {
+  feature_slug: string;
+  enabled: boolean;
+  message: string;
+}
+
+// ============================================================================
 // Tier Info
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Sync from AlterLab PR #19977 — adds four MCP tools for the beta feature management API.

## Changes

- `src/tools/beta_features.ts` (new) — `alterlab_list_beta_features`, `alterlab_list_my_beta_features`, `alterlab_enable_beta_feature`, `alterlab_disable_beta_feature`
- `src/types.ts` — added `BetaFeatureListItem`, `BetaFeatureListResponse`, `BetaFeatureMyResponse`, `BetaFeatureToggleResponse`
- `src/format.ts` — added three formatters with consistent LLM-readable output
- `src/client.ts` — added four client methods mapping to the four API endpoints
- `src/index.ts` — registered all four tools

## Testing

- [ ] `alterlab_list_beta_features` returns feature list with per-feature opt-in state
- [ ] `alterlab_list_my_beta_features` returns compact slug list
- [ ] `alterlab_enable_beta_feature` with valid slug returns enabled confirmation
- [ ] `alterlab_disable_beta_feature` with valid slug returns disabled confirmation
- [ ] `npm run build` passes (verified locally)

---
Closes #233
**Implementation branch**: `feat/beta-features-233`
**Base**: `main`