### PR TITLE
Fix: correct extraction_schema docs and show filtered_content in scrape response

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -25,8 +25,11 @@ export function formatScrapeResponse(response: UnifiedScrapeResponse): string {
     parts.push(`# ${response.title}\n`);
   }
 
-  // Schema-extracted data takes priority when extraction_schema was used
-  if (response.filtered_content) {
+  // Schema-extracted data takes priority when extraction_schema was used.
+  // When filtered_content is present, content.json contains the same data (API mirrors it
+  // there per #19899) — skip the json branch below to avoid double-displaying it.
+  const hasFilteredContent = Boolean(response.filtered_content);
+  if (hasFilteredContent) {
     parts.push(
       "## Extracted Data\n\n" +
         "```json\n" +
@@ -45,7 +48,9 @@ export function formatScrapeResponse(response: UnifiedScrapeResponse): string {
       parts.push(contentMap.text);
     } else if (contentMap.html) {
       parts.push("```html\n" + contentMap.html + "\n```");
-    } else if (contentMap.json) {
+    } else if (contentMap.json && !hasFilteredContent) {
+      // Skip content.json when filtered_content was already shown above —
+      // the API sets content.json = filtered_content when extraction_schema is used.
       parts.push(
         "```json\n" +
           (typeof contentMap.json === "string"
@@ -53,7 +58,12 @@ export function formatScrapeResponse(response: UnifiedScrapeResponse): string {
             : JSON.stringify(contentMap.json, null, 2)) +
           "\n```",
       );
-    } else {
+    } else if (
+      !contentMap.markdown &&
+      !contentMap.text &&
+      !contentMap.html &&
+      !contentMap.json
+    ) {
       // Unknown structure — dump as JSON
       parts.push("```json\n" + JSON.stringify(content, null, 2) + "\n```");
     }

--- a/src/format.ts
+++ b/src/format.ts
@@ -25,6 +25,16 @@ export function formatScrapeResponse(response: UnifiedScrapeResponse): string {
     parts.push(`# ${response.title}\n`);
   }
 
+  // Schema-extracted data takes priority when extraction_schema was used
+  if (response.filtered_content) {
+    parts.push(
+      "## Extracted Data\n\n" +
+        "```json\n" +
+        JSON.stringify(response.filtered_content, null, 2) +
+        "\n```",
+    );
+  }
+
   // Main content — prefer markdown format from multi-format response
   const content = response.content;
   if (typeof content === "object" && content !== null) {

--- a/src/tools/scrape.ts
+++ b/src/tools/scrape.ts
@@ -49,7 +49,7 @@ export const scrapeSchema = z.object({
     .describe(
       "JSON schema for structured extraction. " +
         "The API extracts fields matching this schema from the scraped page using LLM. " +
-        "Result is returned in extraction_result. " +
+        "Result is returned in content.json (add 'json' to formats) and in the top-level filtered_content field. " +
         'Example: { "title": "string", "price": "number", "in_stock": "boolean" }',
     ),
   extraction_model: z
@@ -188,7 +188,7 @@ export const scrapeDescription =
   "Use formats=['json_v2'] for a structured section tree (headings + content blocks). " +
   "Use formats=['rag'] for chunked text optimized for RAG pipelines. " +
   "Use formats=['content'] for AI/KB pipelines — returns body_markdown, content_hash, images, links. " +
-  "Use extraction_schema to extract structured fields from the page using LLM (returned in extraction_result). " +
+  "Use extraction_schema to extract structured fields from the page using LLM (add formats=['json'] to retrieve result in content.json, also available in filtered_content). " +
   "Supports authenticated scraping via session_id (stored session) or inline cookies. " +
   "Use scroll_to_load=true for infinite-scroll pages that lazy-load content. " +
   "Use location.country to scrape geo-targeted content.";


### PR DESCRIPTION
## Summary
- Correct stale `extraction_result` field references in scrape tool descriptions (field never existed)
- Update `formatScrapeResponse` to display schema-extracted data (`filtered_content`) prominently when `extraction_schema` was used
- Syncs MCP server with AlterLab API behavior change from PR #19899

## Changes
- `src/tools/scrape.ts`: Fix `extraction_schema` parameter description and `scrapeDescription` — replace `extraction_result` (non-existent) with accurate docs pointing to `content.json` and `filtered_content`
- `src/format.ts`: Add `filtered_content` check at start of `formatScrapeResponse` — when schema extraction is used, extracted data appears first under "Extracted Data" heading

## Testing
- [ ] Scrape with `extraction_schema` + `formats=["json", "markdown"]` — verify extracted data block appears
- [ ] Scrape without `extraction_schema` — verify standard markdown output unchanged

---
Closes #222
**Implementation branch**: `fix/sync-scrape-api-222`
**Base**: `main`