### PR TITLE
Fix: add extraction_provider, extraction_prompt, extraction_profile to scrape tool

### DIFF
--- a/src/tools/scrape.ts
+++ b/src/tools/scrape.ts
@@ -59,6 +59,44 @@ export const scrapeSchema = z.object({
       "Per-request LLM model override in provider-specific format (e.g. 'gpt-4o', 'claude-opus-4-5-20251101', 'llama3-70b-8192'). " +
         "Overrides the model saved in your BYOK key settings for this request only.",
     ),
+  extraction_provider: z
+    .enum(["openai", "anthropic", "openrouter", "groq"])
+    .optional()
+    .describe(
+      "LLM provider to use for extraction. Selects the matching BYOK key registered at " +
+        "/dashboard/settings/llm-keys. When omitted, the most recently used registered key " +
+        "is used automatically. Requires extraction_schema or extraction_prompt.",
+    ),
+  extraction_prompt: z
+    .string()
+    .max(2000)
+    .optional()
+    .describe(
+      "Natural language extraction instruction. Describes what fields to extract from the page. " +
+        "Mutually exclusive with extraction_schema. " +
+        'Example: "Extract the product name, price, and availability".',
+    ),
+  extraction_profile: z
+    .enum([
+      "auto",
+      "product",
+      "article",
+      "job_posting",
+      "faq",
+      "recipe",
+      "event",
+      "ecommerce_homepage",
+      "directory_listing",
+    ])
+    .optional()
+    .describe(
+      "Pre-built extraction schema template. " +
+        "auto: detect best template. product: e-commerce product details. " +
+        "article: news/blog article fields. job_posting: job listing fields. " +
+        "faq: FAQ entries. recipe: recipe ingredients and instructions. " +
+        "event: event details. ecommerce_homepage: homepage product listings. " +
+        "directory_listing: directory/listing page entries.",
+    ),
   render_js: z
     .union([z.boolean(), z.literal("auto")])
     .default(false)
@@ -189,6 +227,9 @@ export const scrapeDescription =
   "Use formats=['rag'] for chunked text optimized for RAG pipelines. " +
   "Use formats=['content'] for AI/KB pipelines — returns body_markdown, content_hash, images, links. " +
   "Use extraction_schema to extract structured fields from the page using LLM (add formats=['json'] to retrieve result in content.json, also available in filtered_content). " +
+  "Use extraction_prompt for natural language extraction instructions (mutually exclusive with extraction_schema). " +
+  "Use extraction_profile to select a pre-built extraction template (product, article, job_posting, etc.). " +
+  "Use extraction_provider to select a specific BYOK LLM provider (openai, anthropic, openrouter, groq). " +
   "Supports authenticated scraping via session_id (stored session) or inline cookies. " +
   "Use scroll_to_load=true for infinite-scroll pages that lazy-load content. " +
   "Use location.country to scrape geo-targeted content.";
@@ -213,7 +254,10 @@ export async function handleScrape(
       cookies: params.cookies,
       location: params.location,
       extraction_schema: params.extraction_schema,
+      extraction_prompt: params.extraction_prompt,
       extraction_model: params.extraction_model ?? undefined,
+      extraction_provider: params.extraction_provider,
+      extraction_profile: params.extraction_profile,
       advanced: {
         render_js: params.render_js,
         use_proxy: params.use_proxy,

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export interface UnifiedScrapeRequest {
   extraction_schema?: Record<string, unknown>;
   extraction_prompt?: string;
   extraction_model?: string;
+  extraction_provider?: "openai" | "anthropic" | "openrouter" | "groq";
   extraction_profile?:
     | "auto"
     | "product"
@@ -49,7 +50,9 @@ export interface UnifiedScrapeRequest {
     | "job_posting"
     | "faq"
     | "recipe"
-    | "event";
+    | "event"
+    | "ecommerce_homepage"
+    | "directory_listing";
   wait_for?: string;
   screenshot?: boolean;
   wait_until?: string;


### PR DESCRIPTION
## Summary
- Add \`extraction_provider\` (openai/anthropic/openrouter/groq) to scrape tool Zod schema — selects which BYOK key to use for LLM extraction
- Add \`extraction_prompt\` (string, max 2000) — natural language extraction instruction, mutually exclusive with \`extraction_schema\`
- Add \`extraction_profile\` with all 9 values (including new \`ecommerce_homepage\` and \`directory_listing\`)
- Update \`types.ts\`: add \`extraction_provider\` to \`UnifiedScrapeRequest\`, extend \`extraction_profile\` Literal

## Changes
- \`src/tools/scrape.ts\` — 3 new Zod schema fields + handler pass-through + updated description
- \`src/types.ts\` — \`extraction_provider\` field + 2 new \`extraction_profile\` Literal values

## Investigation Note
The issue references \`byok_key_id\`/\`byok_model\`/\`byok_provider\` — these are internal server-side variables computed from the user's registered BYOK keys, not user-facing API parameters. The actual parameters needed were \`extraction_provider\`, \`extraction_prompt\`, and updated \`extraction_profile\`.

## Testing
- [x] \`npm run build\` passes
- [ ] extraction_provider routes to correct BYOK key
- [ ] extraction_prompt triggers LLM extraction
- [ ] extraction_profile=ecommerce_homepage returns structured data

---
Closes #225
**Implementation branch**: \`fix/sync-byok-extraction-params-225\`
**Base**: \`main\`