### PR TITLE
Fix: sync 402 error message with API balance terminology (#229)

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -84,7 +84,7 @@ export function formatErrorResult(
           {
             type: "text",
             text:
-              `Insufficient credits${url}.\n\n` +
+              `Insufficient balance${url}: ${detail}\n\n` +
               "Suggested actions:\n" +
               "- Use `alterlab_check_balance` to see your current balance\n" +
               "- Add funds at: https://alterlab.io/dashboard/billing\n" +


### PR DESCRIPTION
## Summary
Syncs the MCP server's 402 error handler with PR #19971 from the AlterLab API, which changed the `insufficient_credits` response to use balance (dollar) terminology.

## Changes
- `src/errors.ts`: Updated case 402 error message from `"Insufficient credits"` to `"Insufficient balance"`, and added passthrough of the API `detail` field (now a clean user-facing string, safe to display)

## Testing
- [ ] Trigger a 402 from a zero-balance account — confirm "Insufficient balance" message with API detail
- [ ] Confirm suggested actions still appear (check balance, add funds, estimate cost)

---
Closes #229
**Implementation branch**: `fix/sync-balance-402-229`
**Base**: `main`