### PR TITLE
Fix: sync extract response types and cache-hit display with API

### DIFF
--- a/src/tools/extract.ts
+++ b/src/tools/extract.ts
@@ -188,6 +188,10 @@ function formatStandaloneExtractResponse(
   const extractionMethod = String(r.extraction_method ?? "algorithmic");
   const modelUsed = r.model_used ? String(r.model_used) : null;
   const formats = r.formats as Record<string, unknown> | undefined;
+  const cacheHit = Boolean(r.cache_hit);
+  const extractionMetadata = r.extraction_metadata as
+    | Record<string, unknown>
+    | undefined;
 
   const parts: string[] = [];
 
@@ -220,13 +224,27 @@ function formatStandaloneExtractResponse(
     }
   }
 
-  parts.push(
-    "\n---\n" +
-      `Extract ID: \`${extractId}\` | ` +
-      `Method: ${extractionMethod}` +
-      (modelUsed ? ` (${modelUsed})` : "") +
-      ` | Credits: ${creditsUsed}`,
-  );
+  // Build footer with cache + model info from extraction_metadata when available
+  const provider = extractionMetadata?.provider ?? null;
+  const modelFromMeta = extractionMetadata?.model
+    ? String(extractionMetadata.model)
+    : null;
+  const effectiveModel = modelFromMeta ?? modelUsed;
+
+  const footerParts: string[] = [
+    `Extract ID: \`${extractId}\``,
+    `Method: ${extractionMethod}${effectiveModel ? ` (${effectiveModel})` : ""}`,
+  ];
+
+  if (cacheHit) {
+    footerParts.push("Cache: hit");
+  } else if (provider) {
+    footerParts.push(`Provider: ${provider}`);
+  }
+
+  footerParts.push(`Credits: ${creditsUsed}`);
+
+  parts.push("\n---\n" + footerParts.join(" | "));
 
   return parts.join("\n");
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -219,13 +219,51 @@ export interface ExtractRequest {
   cache_ttl?: number;
 }
 
+/**
+ * Per-call extraction transparency metadata returned in POST /v1/extract responses.
+ *
+ * Provides full context about how the extraction was performed: which LLM provider
+ * and model were used, token counts, AlterLab's invocation fee, latency, and whether
+ * a cached result was served. Token counts are null when no LLM was invoked.
+ */
+export interface ExtractionMetadata {
+  /** Extraction mode: 'byok' when BYOK key was used, 'algorithmic' otherwise. */
+  mode: string;
+  /** LLM provider used (openai, anthropic, openrouter, groq), or null if no LLM ran. */
+  provider?: string | null;
+  /** LLM model ID used for extraction, or null if no LLM ran. */
+  model?: string | null;
+  /** Prompt token count reported by the provider, or null if unavailable. */
+  input_tokens?: number | null;
+  /** Completion token count reported by the provider, or null if unavailable. */
+  output_tokens?: number | null;
+  /** AlterLab invocation fee charged in microcents (net of any refunds). */
+  cost_microcents: number;
+  /** Whether a cached extraction result was served. */
+  cached: boolean;
+  /** End-to-end extraction latency in milliseconds. */
+  latency_ms: number;
+}
+
 export interface ExtractResponse {
   extract_id: string;
   formats: Record<string, unknown>;
   credits_used: number;
   model_used?: string;
   extraction_method: string;
+  /** Extraction profile applied (if any). */
+  extraction_profile?: string;
   content_size_chars: number;
+  /**
+   * Full extraction context including provider, model, token usage,
+   * invocation cost, latency, and cache status. Populated on every call.
+   */
+  extraction_metadata?: ExtractionMetadata;
+  /**
+   * True when the LLM extraction result was served from Redis cache.
+   * When true, no LLM call was made and the BYOK invocation fee was not charged.
+   */
+  cache_hit?: boolean;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Syncs the MCP server extract tool with the AlterLab API's current `ExtractResponse` shape, which includes fields added alongside the cache-control feature (PR #19978).

## Changes

- **`src/types.ts`**: Added `ExtractionMetadata` interface (mode, provider, model, input/output tokens, cost_microcents, cached, latency_ms). Extended `ExtractResponse` with `extraction_profile?`, `extraction_metadata?`, `cache_hit?` fields.
- **`src/tools/extract.ts`**: Updated `formatStandaloneExtractResponse` to surface cache hit status and LLM provider from `extraction_metadata` in the tool output footer (e.g. `Cache: hit | Credits: 0`).

## Testing

- `npm run build` passes ✅
- Cache hit responses now show `Cache: hit` in output footer
- Provider info surfaced from `extraction_metadata` when LLM was used

---
Closes #230
**Implementation branch**: `fix/sync-extract-cache-230`
**Base**: `main`