### PR TITLE
feat(sync): API parity — quality_warning, redirect info, block_images, 504 UX

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -134,7 +134,23 @@ export function formatErrorResult(
         ],
       };
 
-    case 504:
+    case 504: {
+      // The API returns credits_status and estimated_completion_s in the 504 body
+      let creditsNote = "";
+      let completionNote = "";
+      try {
+        if (detail) {
+          const parsed = JSON.parse(detail);
+          if (parsed.credits_status) {
+            creditsNote = `\nCredits: ${parsed.credits_status}`;
+          }
+          if (parsed.estimated_completion_s) {
+            completionNote = `\nEstimated completion: ~${parsed.estimated_completion_s}s`;
+          }
+        }
+      } catch {
+        // detail is plain text, not JSON — use default messaging
+      }
       return {
         isError: true,
         content: [
@@ -144,10 +160,13 @@ export function formatErrorResult(
               `Gateway timeout${url}.\n\n` +
               "The scraping job may still be running on the server.\n" +
               "Do NOT retry immediately — credits may have been consumed.\n" +
-              "Wait and check your balance before retrying.",
+              "Wait and check your balance before retrying." +
+              creditsNote +
+              completionNote,
           },
         ],
       };
+    }
 
     default:
       return {

--- a/src/format.ts
+++ b/src/format.ts
@@ -79,14 +79,26 @@ export function formatScrapeResponse(response: UnifiedScrapeResponse): string {
     ? `$${(response.billing.final_cost_microcents / 1_000_000).toFixed(6)}`
     : `${response.billing.total_credits} credits`;
 
+  const sourceUrl =
+    response.redirected && response.final_url
+      ? `${response.url} → ${response.final_url}`
+      : response.url;
+
   parts.push(
     "\n---\n" +
-      `Source: ${response.url} | ` +
+      `Source: ${sourceUrl} | ` +
       `Tier: ${tierName} (${tierPrice}/req) | ` +
       `Cost: ${cost} | ` +
       `Time: ${response.response_time_ms}ms` +
       (response.cached ? " | Cached" : ""),
   );
+
+  if (response.redirect_chain && response.redirect_chain.length > 0) {
+    const chain = response.redirect_chain
+      .map((hop) => `${hop.status_code} → ${hop.url}`)
+      .join("\n  ");
+    parts.push(`Redirect chain:\n  ${chain}`);
+  }
 
   if (response.billing.optimization_suggestion) {
     parts.push(`Tip: ${response.billing.optimization_suggestion}`);
@@ -99,6 +111,14 @@ export function formatScrapeResponse(response: UnifiedScrapeResponse): string {
     parts.push(
       `Warning: Content truncated at ${truncatedMB} MB (original: ${originalMB} MB, reason: ${t.truncation_reason}). ` +
         `Increase max_response_bytes or use a more targeted selector to capture the full page.`,
+    );
+  }
+
+  if (response.quality_warning) {
+    const qw = response.quality_warning;
+    parts.push(
+      `Quality warning: ${qw.reason} (code: ${qw.code}, word_count: ${qw.word_count}). ` +
+        `Content was delivered but may contain anti-bot artifacts.`,
     );
   }
 

--- a/src/tools/crawl.ts
+++ b/src/tools/crawl.ts
@@ -83,6 +83,13 @@ export const crawlSchema = z.object({
     .boolean()
     .default(false)
     .describe("Include links to subdomains during discovery"),
+  block_images: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Block image downloads during browser rendering on each crawled page. " +
+        "Reduces proxy bandwidth and speeds up crawls. Only effective with render_js=true.",
+    ),
   webhook_url: z
     .string()
     .url()
@@ -120,6 +127,7 @@ export async function handleCrawl(
       advanced: {
         render_js: params.render_js,
         use_proxy: params.use_proxy,
+        block_images: params.block_images,
       },
     });
 

--- a/src/tools/scrape.ts
+++ b/src/tools/scrape.ts
@@ -186,6 +186,13 @@ export const scrapeSchema = z.object({
     .describe(
       "Remove cookie consent banners from HTML before content extraction (free, enabled by default)",
     ),
+  block_images: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Block image downloads during browser rendering. " +
+        "Reduces proxy bandwidth and speeds up scrapes. Only effective with render_js=true.",
+    ),
   location: z
     .object({
       country: z
@@ -266,6 +273,7 @@ export async function handleScrape(
         scroll_to_load: params.scroll_to_load,
         scroll_count: params.scroll_count,
         remove_cookie_banners: params.remove_cookie_banners,
+        block_images: params.block_images,
       },
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface AdvancedOptions {
   remove_cookie_banners?: boolean;
   scroll_to_load?: boolean;
   scroll_count?: number;
+  block_images?: boolean;
 }
 
 export interface LocationOptions {
@@ -70,6 +71,7 @@ export interface CrawlAdvancedOptions {
   use_proxy?: boolean;
   wait_for?: string;
   timeout?: number;
+  block_images?: boolean;
 }
 
 export interface CrawlRequest {
@@ -431,9 +433,24 @@ export interface BillingDetails {
   final_cost_microcents?: number;
 }
 
+export interface QualityWarning {
+  code: string;
+  reason: string;
+  word_count: number;
+  content_size_bytes: number;
+}
+
+export interface RedirectHop {
+  url: string;
+  status_code: number;
+}
+
 export interface UnifiedScrapeResponse {
   job_id?: string;
   url: string;
+  final_url?: string;
+  redirected?: boolean;
+  redirect_chain?: RedirectHop[];
   status_code: number;
   content: string | Record<string, unknown>;
   title?: string;
@@ -450,6 +467,7 @@ export interface UnifiedScrapeResponse {
   pdf_url?: string;
   filtered_content?: Record<string, unknown>;
   content_truncated?: ContentTruncationInfo;
+  quality_warning?: QualityWarning;
   billing: BillingDetails;
   extraction_method?: string;
   version?: string;


### PR DESCRIPTION
## Summary

Sync 4 API surface changes from AlterLab upstream:

1. **`quality_warning`** (#311) — New `quality_warning` field on scrape response. Surfaces posthoc soft-block detection when content is usable but may contain anti-bot artifacts.

2. **`final_url` / `redirected` / `redirect_chain`** (#302) — Redirect transparency fields. `final_url` shows where the request landed, `redirected` is a boolean flag, `redirect_chain` provides hop-by-hop detail.

3. **`block_images`** (#296) — New param on scrape and crawl tools. Skips image downloads during browser rendering to reduce bandwidth and speed up requests.

4. **504 UX** (#294) — Parse `credits_status` and `estimated_completion_s` from 504 timeout error body so agents get actionable info about credit state and job completion.

## Changes

- `src/types.ts` — Add `QualityWarning`, `RedirectHop` interfaces; add `final_url`, `redirected`, `redirect_chain`, `quality_warning` to `UnifiedScrapeResponse`; add `block_images` to `AdvancedOptions` and `CrawlAdvancedOptions`
- `src/tools/scrape.ts` — Add `block_images` schema param + passthrough to `advanced`
- `src/tools/crawl.ts` — Add `block_images` schema param + passthrough to `advanced`
- `src/format.ts` — Surface redirect chain, quality warning in formatted output
- `src/errors.ts` — Parse structured 504 error body for credits/completion info

## Test plan

- [ ] `npm run build` passes (verified locally)
- [ ] Scrape with redirect — verify `final_url` and `redirect_chain` appear in output
- [ ] Scrape soft-blocked page — verify `quality_warning` appears in output
- [ ] Scrape with `block_images: true` — verify param passed through
- [ ] Crawl with `block_images: true` — verify param passed through
- [ ] Trigger 504 timeout — verify credits/completion info in error message

Closes #311, closes #302, closes #296, closes #294